### PR TITLE
Improve error message for untagged Tailscale nodes

### DIFF
--- a/tailscale/service.go
+++ b/tailscale/service.go
@@ -173,6 +173,20 @@ func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService)
 			return nil
 		}
 
+		if isUntaggedNodeError(stderr) {
+			return fmt.Errorf("failed to add service: your Tailscale node is not tagged. " +
+				"Tailscale Services require the host node to advertise ACL tags.\n" +
+				"To fix this:\n" +
+				"  1. Tag your Tailscale node:\n" +
+				"     - Host install: sudo tailscale up --advertise-tags=tag:server --reset\n" +
+				"     - Sidecar container: set TS_EXTRA_ARGS=--advertise-tags=tag:server in your Tailscale container's environment\n" +
+				"     - Or tag it in the Tailscale admin console: https://login.tailscale.com/admin/machines → click your node → Edit ACL tags\n" +
+				"  2. Add an ACL auto-approver at https://login.tailscale.com/admin/acls:\n" +
+				"     \"autoApprovers\": { \"services\": { \"tag:container\": [\"tag:server\"] } }\n" +
+				"  3. Approve the service at https://login.tailscale.com/admin/services\n" +
+				"Full setup guide: https://github.com/marvinvr/docktail#tailscale-admin-setup")
+		}
+
 		return fmt.Errorf("failed to add service: %w\nOutput: %s", err, stderr)
 	}
 

--- a/tailscale/utils.go
+++ b/tailscale/utils.go
@@ -39,6 +39,11 @@ func isConfigConflictError(stderr string) bool {
 		strings.Contains(stderr, "port is already serving")
 }
 
+// isUntaggedNodeError checks if the error is because the Tailscale node is not tagged
+func isUntaggedNodeError(stderr string) bool {
+	return strings.Contains(stderr, "service hosts must be tagged nodes")
+}
+
 // isManagedService checks if a service name has the "svc:" prefix
 // This indicates it's managed by DockTail and safe to modify
 func isManagedService(serviceName string) bool {


### PR DESCRIPTION
closes: #12
## Summary

When a user tries to advertise a service but their Tailscale node isn't tagged, they get the cryptic error `service hosts must be tagged nodes` from the Tailscale CLI with no guidance on how to fix it.

This PR adds detection for that specific error and provides a clear, multi-step guide that tells users:
1. How to define tags in the ACL file
2. How to tag their node (via `TS_EXTRA_ARGS` env var or admin console)
3. How to configure ACL autoApprovers

The error message now includes links to relevant Tailscale documentation so users don't have to guess.

## Changes

- Add `isUntaggedNodeError()` helper in `tailscale/utils.go` to detect the tagging error
- In `tailscale/service.go`, check for this error before falling back to generic error message
- Return actionable error with step-by-step instructions and documentation links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messaging for untagged nodes with detailed remediation guidance, including node tagging, auto-approver configuration, and service approval steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->