### PR TITLE
Add healthcheck and use directory mount for Tailscale socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,7 @@ WORKDIR /app
 # Copy binary from build stage
 COPY --from=builder /build/docktail .
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD tailscale --socket=${TAILSCALE_SOCKET:-/var/run/tailscale/tailscaled.sock} serve status || exit 1
+
 ENTRYPOINT ["/bin/sh", "-c", "sleep 1 && exec /app/docktail"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+      - /var/run/tailscale:/var/run/tailscale
     environment:
       # Optional but recommended - enables auto-service-creation
       - TAILSCALE_OAUTH_CLIENT_ID=${TAILSCALE_OAUTH_CLIENT_ID}
@@ -112,12 +112,14 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+      - /var/run/tailscale:/var/run/tailscale
     environment:
       # Optional but recommended - enables auto-service-creation
       - TAILSCALE_OAUTH_CLIENT_ID=${TAILSCALE_OAUTH_CLIENT_ID}
       - TAILSCALE_OAUTH_CLIENT_SECRET=${TAILSCALE_OAUTH_CLIENT_SECRET}
 ```
+
+> **Note:** We mount the `/var/run/tailscale` directory rather than the socket file directly. When `tailscaled` restarts, it recreates the socket with a new inode — a file bind mount would go stale, but a directory mount stays in sync automatically.
 
 **Host tag requirement:** The host machine running Tailscale must advertise a tag that matches your ACL auto-approvers (see [Tailscale Admin Setup](#tailscale-admin-setup)). For example:
 

--- a/docker-compose.console-sync.yaml
+++ b/docker-compose.console-sync.yaml
@@ -13,7 +13,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+      - /var/run/tailscale:/var/run/tailscale
     environment:
       - LOG_LEVEL=debug
       - TAILSCALE_TAILNET=${TAILSCALE_TAILNET:-}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
     volumes:
       # Docker socket for container monitoring
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      # Tailscale socket for CLI communication
-      - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+      # Tailscale socket directory (directory mount survives tailscaled restarts)
+      - /var/run/tailscale:/var/run/tailscale
     environment:
       - LOG_LEVEL=debug
       - RECONCILE_INTERVAL=60s


### PR DESCRIPTION
## Summary

- Add a `HEALTHCHECK` to the Dockerfile using `tailscale serve status`, so Docker can detect when docktail loses connectivity to the Tailscale daemon
- Switch all compose examples and docs from mounting the socket file directly (`tailscaled.sock`) to mounting the `/var/run/tailscale` directory

## Problem

When `tailscaled` restarts (host reboot, service restart, update), it recreates the socket with a new inode. A file bind mount goes stale — the file appears to exist inside the container, but connections are refused. Docktail keeps running and retrying, but Docker reports the container as healthy since there's no healthcheck.

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Add `HEALTHCHECK` using `tailscale serve status` |
| `README.md` | Update Quick Start and Installation sections to use directory mount; add explanatory note |
| `docker-compose.yaml` | Use directory mount |
| `docker-compose.console-sync.yaml` | Use directory mount |

The sidecar and e2e composes already use shared volumes (directory mount), so no changes needed there.

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added container health checks and a brief startup delay to improve service stability and automated health monitoring.

* **Documentation**
  * Updated deployment examples with improved Tailscale integration (mounting the runtime directory) and guidance so connectivity remains reliable across container restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->