### PR TITLE
Add healthcheck and use directory mount for Tailscale socket (#27)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,7 @@ WORKDIR /app
 # Copy binary from build stage
 COPY --from=builder /build/docktail .
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD tailscale --socket=${TAILSCALE_SOCKET:-/var/run/tailscale/tailscaled.sock} serve status || exit 1
+
 ENTRYPOINT ["/bin/sh", "-c", "sleep 1 && exec /app/docktail"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+      - /var/run/tailscale:/var/run/tailscale
     environment:
       # Optional but recommended - enables auto-service-creation
       - TAILSCALE_OAUTH_CLIENT_ID=${TAILSCALE_OAUTH_CLIENT_ID}
@@ -112,12 +112,14 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+      - /var/run/tailscale:/var/run/tailscale
     environment:
       # Optional but recommended - enables auto-service-creation
       - TAILSCALE_OAUTH_CLIENT_ID=${TAILSCALE_OAUTH_CLIENT_ID}
       - TAILSCALE_OAUTH_CLIENT_SECRET=${TAILSCALE_OAUTH_CLIENT_SECRET}
 ```
+
+> **Note:** We mount the `/var/run/tailscale` directory rather than the socket file directly. When `tailscaled` restarts, it recreates the socket with a new inode — a file bind mount would go stale, but a directory mount stays in sync automatically.
 
 **Host tag requirement:** The host machine running Tailscale must advertise a tag that matches your ACL auto-approvers (see [Tailscale Admin Setup](#tailscale-admin-setup)). For example:
 

--- a/docker-compose.console-sync.yaml
+++ b/docker-compose.console-sync.yaml
@@ -13,7 +13,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+      - /var/run/tailscale:/var/run/tailscale
     environment:
       - LOG_LEVEL=debug
       - TAILSCALE_TAILNET=${TAILSCALE_TAILNET:-}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
     volumes:
       # Docker socket for container monitoring
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      # Tailscale socket for CLI communication
-      - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+      # Tailscale socket directory (directory mount survives tailscaled restarts)
+      - /var/run/tailscale:/var/run/tailscale
     environment:
       - LOG_LEVEL=debug
       - RECONCILE_INTERVAL=60s


### PR DESCRIPTION
Add a HEALTHCHECK to the Dockerfile so Docker can detect when docktail loses connectivity to the Tailscale daemon. Uses `tailscale serve status` which fails immediately if the socket is unreachable.

Switch all compose examples and docs from mounting the socket file directly to mounting the /var/run/tailscale directory. When tailscaled restarts, it recreates the socket with a new inode — a file bind mount goes stale (connection refused despite the file appearing to exist), but a directory mount stays in sync automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service health checks to monitor availability.

* **Bug Fixes**
  * Improved stability during service restarts by updating volume mount configuration to prevent stale connections.

* **Documentation**
  * Updated Docker Compose examples with improved volume mounting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->