### PR TITLE
Add IGNORE_SERVICE_NAMES for manual Tailscale services

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,12 +402,15 @@ Access:
 | `TAILSCALE_API_KEY` | - | API Key (optional alternative to OAuth, expires 90 days) |
 | `TAILSCALE_TAILNET` | `-` | Tailnet ID (defaults to key's tailnet) |
 | `DEFAULT_SERVICE_TAGS` | `tag:container` | Default tags for services |
+| `IGNORE_SERVICE_NAMES` | - | Comma-separated service names DockTail must not drain or clear during reconciliation or shutdown cleanup |
 | `LOG_LEVEL` | `info` | Logging level (debug, info, warn, error) |
 | `RECONCILE_INTERVAL` | `60s` | State reconciliation interval |
 | `DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon socket |
 | `TAILSCALE_SOCKET` | `/var/run/tailscale/tailscaled.sock` | Tailscale daemon socket |
 
 If both OAuth and API key are set, OAuth takes precedence.
+
+`IGNORE_SERVICE_NAMES` accepts either bare names like `grafana` or fully qualified names like `svc:grafana`.
 
 ### Supported Protocols
 

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -42,6 +42,7 @@ services:
       - LOG_LEVEL=debug
       - RECONCILE_INTERVAL=5s
       - DEFAULT_SERVICE_TAGS=tag:ci-test-container
+      - IGNORE_SERVICE_NAMES=e2e-manual-protected
       - TAILSCALE_OAUTH_CLIENT_ID=${TS_OAUTH_CLIENT_ID:-}
       - TAILSCALE_OAUTH_CLIENT_SECRET=${TS_OAUTH_CLIENT_SECRET:-}
       - TAILSCALE_TAILNET=${TS_TAILNET:-}

--- a/docker-compose.sidecar.yaml
+++ b/docker-compose.sidecar.yaml
@@ -45,6 +45,7 @@ services:
     environment:
       - LOG_LEVEL=info
       - RECONCILE_INTERVAL=60s
+      # - IGNORE_SERVICE_NAMES=plug-soudan-pi5,grafana
       # Optional: Control Plane Sync (uncomment to enable)
       # - TAILSCALE_API_KEY=${TAILSCALE_API_KEY}
       # - TAILSCALE_TAILNET=${TAILSCALE_TAILNET:-}

--- a/e2e.sh
+++ b/e2e.sh
@@ -7,7 +7,7 @@ MAX_WAIT=120
 RECONCILE_WAIT=10
 SCRIPT_TIMEOUT=600
 MANUAL_PROTECTED_SERVICE_NAME="svc:e2e-manual-protected"
-MANUAL_PROTECTED_SERVICE_PORT="18081"
+MANUAL_PROTECTED_SERVICE_PORT="80"
 
 # Kill the script if it runs longer than SCRIPT_TIMEOUT seconds
 ( sleep "$SCRIPT_TIMEOUT" && echo "ERROR: E2E script timed out after ${SCRIPT_TIMEOUT}s" && kill $$ ) 2>/dev/null &

--- a/e2e.sh
+++ b/e2e.sh
@@ -6,6 +6,8 @@ DOCKTAIL_CONTAINER="e2e-docktail"
 MAX_WAIT=120
 RECONCILE_WAIT=10
 SCRIPT_TIMEOUT=600
+MANUAL_PROTECTED_SERVICE_NAME="svc:e2e-manual-protected"
+MANUAL_PROTECTED_SERVICE_PORT="18081"
 
 # Kill the script if it runs longer than SCRIPT_TIMEOUT seconds
 ( sleep "$SCRIPT_TIMEOUT" && echo "ERROR: E2E script timed out after ${SCRIPT_TIMEOUT}s" && kill $$ ) 2>/dev/null &
@@ -204,6 +206,17 @@ get_funnel_status() {
     docker exec "$TS_CONTAINER" tailscale funnel status --json 2>/dev/null || echo "{}"
 }
 
+create_manual_protected_service() {
+    docker exec "$TS_CONTAINER" tailscale serve \
+        --service="$MANUAL_PROTECTED_SERVICE_NAME" \
+        --http="$MANUAL_PROTECTED_SERVICE_PORT" \
+        http://127.0.0.1:19080 >/dev/null 2>&1
+}
+
+clear_manual_protected_service() {
+    docker exec "$TS_CONTAINER" tailscale serve clear "$MANUAL_PROTECTED_SERVICE_NAME" >/dev/null 2>&1 || true
+}
+
 assert_funnel_active() {
     local port="$1"
     local funnel_status
@@ -372,10 +385,38 @@ log "7. Ignored Container"
 assert_service_not_exists   "e2e-ignored"
 
 # ==============================================================================
-# 8. Lifecycle: service removal on container stop
+# 8. Ignore Service Names: keep manual svc:* entries
 # ==============================================================================
 
-log "8. Lifecycle"
+log "8. Ignore Service Names"
+
+echo "  --- Creating manual protected service ---"
+clear_manual_protected_service
+create_manual_protected_service
+refresh_serve_status
+assert_service_exists       "e2e-manual-protected"
+assert_service_port         "e2e-manual-protected" "$MANUAL_PROTECTED_SERVICE_PORT"
+assert_service_protocol     "e2e-manual-protected" "http"
+assert_service_destination_contains "e2e-manual-protected" "127.0.0.1:19080"
+
+echo "  Waiting for reconciliation while protected service exists..."
+sleep "$RECONCILE_WAIT"
+refresh_serve_status
+
+echo "  --- Post-reconcile: manual protected service should still exist ---"
+assert_service_exists       "e2e-manual-protected"
+assert_service_port         "e2e-manual-protected" "$MANUAL_PROTECTED_SERVICE_PORT"
+
+echo "  --- Cleaning up manual protected service ---"
+clear_manual_protected_service
+refresh_serve_status
+assert_service_not_exists   "e2e-manual-protected"
+
+# ==============================================================================
+# 9. Lifecycle: service removal on container stop
+# ==============================================================================
+
+log "9. Lifecycle"
 
 echo "  --- Pre-check: lifecycle service exists ---"
 assert_service_exists       "e2e-lifecycle"
@@ -394,10 +435,10 @@ assert_service_exists       "e2e-proto-http"
 assert_service_exists       "e2e-proto-https"
 
 # ==============================================================================
-# 9. Service Update: change protocol from HTTP to HTTPS
+# 10. Service Update: change protocol from HTTP to HTTPS
 # ==============================================================================
 
-log "9. Service Update"
+log "10. Service Update"
 
 echo "  --- Pre-check: update service is HTTP/80 ---"
 assert_service_exists       "e2e-update"
@@ -427,10 +468,10 @@ assert_service_port         "e2e-update" "443"
 assert_service_protocol     "e2e-update" "https"
 
 # ==============================================================================
-# 10. Idempotency: reconciling again changes nothing
+# 11. Idempotency: reconciling again changes nothing
 # ==============================================================================
 
-log "10. Idempotency"
+log "11. Idempotency"
 echo "  Waiting for another reconciliation cycle..."
 sleep "$RECONCILE_WAIT"
 refresh_serve_status
@@ -445,18 +486,25 @@ assert_service_exists       "e2e-multiport"
 assert_service_exists       "e2e-multiport-three"
 assert_service_not_exists   "e2e-lifecycle"  # still removed
 assert_service_not_exists   "e2e-ignored"    # still ignored
+assert_service_not_exists   "e2e-manual-protected"  # cleaned up explicitly
 
 # ==============================================================================
-# 11. Log Health
+# 12. Log Health
 # ==============================================================================
 
-log "11. DockTail Log Health"
+log "12. DockTail Log Health"
 docktail_logs=$(docker logs "$DOCKTAIL_CONTAINER" 2>&1)
 
 if echo "$docktail_logs" | grep -qE "FATAL|panic"; then
     fail "FATAL or panic in logs"
 else
     pass "no FATAL or panic in logs"
+fi
+
+if echo "$docktail_logs" | grep -q "Skipping removal for ignored service"; then
+    pass "ignored service skip logged"
+else
+    fail "ignored service skip was not logged"
 fi
 
 # ==============================================================================

--- a/e2e.sh
+++ b/e2e.sh
@@ -228,6 +228,26 @@ assert_funnel_active() {
     fi
 }
 
+wait_for_docktail_log() {
+    local pattern="$1"
+    local timeout="${2:-$RECONCILE_WAIT}"
+    local elapsed=0
+    local logs
+
+    while [ "$elapsed" -lt "$timeout" ]; do
+        logs=$(docker logs "$DOCKTAIL_CONTAINER" 2>&1 || true)
+        if grep -q -- "$pattern" <<<"$logs"; then
+            pass "docktail log contains '$pattern'"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    fail "docktail log missing '$pattern'"
+    return 1
+}
+
 # ==============================================================================
 # Start the stack
 # ==============================================================================
@@ -406,6 +426,7 @@ refresh_serve_status
 echo "  --- Post-reconcile: manual protected service should still exist ---"
 assert_service_exists       "e2e-manual-protected"
 assert_service_port         "e2e-manual-protected" "$MANUAL_PROTECTED_SERVICE_PORT"
+wait_for_docktail_log "Skipping removal for ignored service"
 
 echo "  --- Cleaning up manual protected service ---"
 clear_manual_protected_service
@@ -495,16 +516,10 @@ assert_service_not_exists   "e2e-manual-protected"  # cleaned up explicitly
 log "12. DockTail Log Health"
 docktail_logs=$(docker logs "$DOCKTAIL_CONTAINER" 2>&1)
 
-if echo "$docktail_logs" | grep -qE "FATAL|panic"; then
+if grep -qE "FATAL|panic" <<<"$docktail_logs"; then
     fail "FATAL or panic in logs"
 else
     pass "no FATAL or panic in logs"
-fi
-
-if echo "$docktail_logs" | grep -q "Skipping removal for ignored service"; then
-    pass "ignored service skip logged"
-else
-    fail "ignored service skip was not logged"
 fi
 
 # ==============================================================================

--- a/main.go
+++ b/main.go
@@ -34,12 +34,21 @@ func main() {
 	tailscaleOAuthClientSecret := getEnv("TAILSCALE_OAUTH_CLIENT_SECRET", "")
 	tailscaleTailnet := getEnv("TAILSCALE_TAILNET", "-")
 	defaultTagsStr := getEnv("DEFAULT_SERVICE_TAGS", "tag:container")
+	ignoreServiceNamesStr := getEnv("IGNORE_SERVICE_NAMES", "")
 
 	// Parse default tags
 	var defaultTags []string
 	for _, tag := range strings.Split(defaultTagsStr, ",") {
 		if trimmed := strings.TrimSpace(tag); trimmed != "" {
 			defaultTags = append(defaultTags, trimmed)
+		}
+	}
+
+	// Parse ignored service names
+	var ignoreServiceNames []string
+	for _, name := range strings.Split(ignoreServiceNamesStr, ",") {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			ignoreServiceNames = append(ignoreServiceNames, trimmed)
 		}
 	}
 
@@ -57,6 +66,7 @@ func main() {
 		Str("api_sync_method", apiSyncMethod).
 		Str("tailnet", tailscaleTailnet).
 		Strs("default_tags", defaultTags).
+		Strs("ignore_service_names", ignoreServiceNames).
 		Msg("Configuration loaded")
 
 	// Create Docker client
@@ -70,11 +80,12 @@ func main() {
 
 	// Create Tailscale client
 	tailscaleClient := tailscale.NewClient(tailscale.ClientConfig{
-		SocketPath:        tailscaleSocket,
-		Tailnet:           tailscaleTailnet,
-		APIKey:            tailscaleAPIKey,
-		OAuthClientID:     tailscaleOAuthClientID,
-		OAuthClientSecret: tailscaleOAuthClientSecret,
+		SocketPath:         tailscaleSocket,
+		Tailnet:            tailscaleTailnet,
+		APIKey:             tailscaleAPIKey,
+		OAuthClientID:      tailscaleOAuthClientID,
+		OAuthClientSecret:  tailscaleOAuthClientSecret,
+		IgnoreServiceNames: ignoreServiceNames,
 	})
 
 	// Detect CLI/daemon version mismatch (common with host-mode Tailscale)

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -19,30 +19,40 @@ import (
 
 // Client handles Tailscale CLI interactions and API calls
 type Client struct {
-	socketPath     string
-	tailnet        string
-	baseURL        string
-	httpClient     *http.Client
-	apiSyncEnabled bool
-	serverVersion  string // set when CLI/daemon version mismatch detected
+	socketPath      string
+	tailnet         string
+	baseURL         string
+	httpClient      *http.Client
+	apiSyncEnabled  bool
+	serverVersion   string // set when CLI/daemon version mismatch detected
+	ignoredServices map[string]struct{}
 }
 
 // ClientConfig holds configuration for creating a Tailscale client
 type ClientConfig struct {
-	SocketPath        string
-	Tailnet           string
-	APIKey            string
-	OAuthClientID     string
-	OAuthClientSecret string
+	SocketPath         string
+	Tailnet            string
+	APIKey             string
+	OAuthClientID      string
+	OAuthClientSecret  string
+	IgnoreServiceNames []string
 }
 
 // NewClient creates a new Tailscale client
 // Prefers OAuth credentials over API key if both are provided
 func NewClient(cfg ClientConfig) *Client {
 	client := &Client{
-		socketPath: cfg.SocketPath,
-		tailnet:    cfg.Tailnet,
-		baseURL:    "https://api.tailscale.com",
+		socketPath:      cfg.SocketPath,
+		tailnet:         cfg.Tailnet,
+		baseURL:         "https://api.tailscale.com",
+		ignoredServices: make(map[string]struct{}),
+	}
+
+	for _, serviceName := range cfg.IgnoreServiceNames {
+		normalized := normalizeServiceName(serviceName)
+		if normalized != "" {
+			client.ignoredServices[normalized] = struct{}{}
+		}
 	}
 
 	// Prefer OAuth over API key
@@ -186,6 +196,13 @@ func (c *Client) ReconcileServices(ctx context.Context, desiredServices []*appty
 	// Find services to remove (in current but not in desired)
 	for key, current := range currentServices {
 		if _, exists := desiredMap[key]; !exists {
+			if c.shouldIgnoreService(current.ServiceName) {
+				log.Info().
+					Str("service", current.ServiceName).
+					Str("port", current.Port).
+					Msg("Skipping removal for ignored service")
+				continue
+			}
 			toRemove[key] = current
 		}
 	}
@@ -517,6 +534,14 @@ func (c *Client) CleanupAllServices(ctx context.Context) error {
 	failCount := 0
 
 	for _, svc := range currentServices {
+		if c.shouldIgnoreService(svc.ServiceName) {
+			log.Info().
+				Str("service", svc.ServiceName).
+				Str("port", svc.Port).
+				Msg("Skipping cleanup for ignored service")
+			continue
+		}
+
 		log.Info().
 			Str("service", svc.ServiceName).
 			Str("port", svc.Port).

--- a/tailscale/service.go
+++ b/tailscale/service.go
@@ -246,6 +246,13 @@ func (c *Client) removeService(ctx context.Context, serviceName string) error {
 		return fmt.Errorf("refusing to remove service '%s': not managed by DockTail (missing 'svc:' prefix)", serviceName)
 	}
 
+	if c.shouldIgnoreService(serviceName) {
+		log.Info().
+			Str("service", serviceName).
+			Msg("Refusing to remove ignored service")
+		return nil
+	}
+
 	log.Info().
 		Str("service", serviceName).
 		Msg("Gracefully removing service: draining then clearing")

--- a/tailscale/utils.go
+++ b/tailscale/utils.go
@@ -107,7 +107,8 @@ func isManagedService(serviceName string) bool {
 }
 
 func normalizeServiceName(serviceName string) string {
-	return strings.TrimPrefix(strings.TrimSpace(serviceName), "svc:")
+	normalized := strings.ToLower(strings.TrimSpace(serviceName))
+	return strings.TrimPrefix(normalized, "svc:")
 }
 
 func (c *Client) shouldIgnoreService(serviceName string) bool {

--- a/tailscale/utils.go
+++ b/tailscale/utils.go
@@ -106,6 +106,19 @@ func isManagedService(serviceName string) bool {
 	return strings.HasPrefix(serviceName, "svc:")
 }
 
+func normalizeServiceName(serviceName string) string {
+	return strings.TrimPrefix(strings.TrimSpace(serviceName), "svc:")
+}
+
+func (c *Client) shouldIgnoreService(serviceName string) bool {
+	if len(c.ignoredServices) == 0 {
+		return false
+	}
+
+	_, ok := c.ignoredServices[normalizeServiceName(serviceName)]
+	return ok
+}
+
 // buildDestination constructs the destination URL for a service
 func buildDestination(svc *apptypes.ContainerService) string {
 	// Use the service protocol directly in the destination URL

--- a/tailscale/utils_test.go
+++ b/tailscale/utils_test.go
@@ -156,6 +156,9 @@ func TestNormalizeServiceName(t *testing.T) {
 		{"bare name", "manual-service", "manual-service"},
 		{"svc prefix", "svc:manual-service", "manual-service"},
 		{"whitespace trimmed", "  svc:trimmed  ", "trimmed"},
+		{"uppercase prefix", "SVC:Manual-Service", "manual-service"},
+		{"mixed case and whitespace", "  SvC:Trimmed  ", "trimmed"},
+		{"uppercase bare name", "MANUAL-SERVICE", "manual-service"},
 		{"empty string", "", ""},
 	}
 
@@ -173,6 +176,7 @@ func TestShouldIgnoreService(t *testing.T) {
 	client := &Client{
 		ignoredServices: map[string]struct{}{
 			"manual-service": {},
+			"trimmed":        {},
 		},
 	}
 
@@ -183,6 +187,9 @@ func TestShouldIgnoreService(t *testing.T) {
 	}{
 		{"bare name matches", "manual-service", true},
 		{"svc prefix matches", "svc:manual-service", true},
+		{"uppercase prefix matches", "SVC:Manual-Service", true},
+		{"mixed case and whitespace matches", "  SvC:Trimmed  ", true},
+		{"uppercase bare name matches", "MANUAL-SERVICE", true},
 		{"different service", "svc:other-service", false},
 		{"empty service", "", false},
 	}
@@ -194,6 +201,32 @@ func TestShouldIgnoreService(t *testing.T) {
 				t.Errorf("shouldIgnoreService(%q) = %v, want %v", tt.serviceName, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestNewClientNormalizesIgnoredServices(t *testing.T) {
+	client := NewClient(ClientConfig{
+		IgnoreServiceNames: []string{
+			"SVC:Manual-Service",
+			"  SvC:Trimmed  ",
+			"MANUAL-SERVICE",
+		},
+	})
+
+	if _, ok := client.ignoredServices["manual-service"]; !ok {
+		t.Fatalf("ignoredServices missing normalized key %q", "manual-service")
+	}
+
+	if _, ok := client.ignoredServices["trimmed"]; !ok {
+		t.Fatalf("ignoredServices missing normalized key %q", "trimmed")
+	}
+
+	if _, ok := client.ignoredServices["SVC:Manual-Service"]; ok {
+		t.Fatalf("ignoredServices should not retain unnormalized key %q", "SVC:Manual-Service")
+	}
+
+	if got, want := len(client.ignoredServices), 2; got != want {
+		t.Fatalf("len(ignoredServices) = %d, want %d", got, want)
 	}
 }
 

--- a/tailscale/utils_test.go
+++ b/tailscale/utils_test.go
@@ -147,6 +147,56 @@ func TestIsManagedService(t *testing.T) {
 	}
 }
 
+func TestNormalizeServiceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"bare name", "manual-service", "manual-service"},
+		{"svc prefix", "svc:manual-service", "manual-service"},
+		{"whitespace trimmed", "  svc:trimmed  ", "trimmed"},
+		{"empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeServiceName(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeServiceName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestShouldIgnoreService(t *testing.T) {
+	client := &Client{
+		ignoredServices: map[string]struct{}{
+			"manual-service": {},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		serviceName string
+		expected    bool
+	}{
+		{"bare name matches", "manual-service", true},
+		{"svc prefix matches", "svc:manual-service", true},
+		{"different service", "svc:other-service", false},
+		{"empty service", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := client.shouldIgnoreService(tt.serviceName)
+			if result != tt.expected {
+				t.Errorf("shouldIgnoreService(%q) = %v, want %v", tt.serviceName, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestBuildDestination(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- add `IGNORE_SERVICE_NAMES` to protect named `svc:` services from DockTail reconciliation cleanup
- apply the ignore list during both regular reconciliation and shutdown cleanup, with normalization so either `foo` or `svc:foo` works
- document the new env var and add e2e coverage for a manually created protected service (`svc:e2e-manual-protected`)

## Testing
- `docker run --rm -v /home/mvr/Development/docktail:/src -w /src golang:1.25.1 go test ./...`
- e2e not run in this session

closes: #9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IGNORE_SERVICE_NAMES env var to preserve listed services from automated removal; accepts bare or fully qualified names.

* **Documentation**
  * README updated with usage and examples for IGNORE_SERVICE_NAMES.

* **Configuration**
  * Compose examples updated to set or show IGNORE_SERVICE_NAMES entries/comments.

* **Tests**
  * End-to-end and unit tests added/updated to verify ignore behavior, logs, and service preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->