### PR TITLE
Add warning when converting https service to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ services:
 
 Access: `https://api.your-tailnet.ts.net`
 
-> **Note:** If switching an existing service from http to https, you must first delete it from the tailscale advertized service panel.
+> **Note:** If switching an existing service from http to https, you must first delete it from the Tailscale advertised service panel.
 
 ### Database (TCP)
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ services:
 
 Access: `https://api.your-tailnet.ts.net`
 
+> **Note:** If switching an existing service from http to https, you must first delete it from the tailscale advertized service panel.
+
 ### Database (TCP)
 
 ```yaml


### PR DESCRIPTION
add warning about converting to https

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified in the "HTTPS with Auto TLS" example that when converting an existing service from HTTP to HTTPS, you must first remove the previously advertised service from the Tailscale advertised service panel before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->