### PR TITLE
Support funnel-only containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ DockTail automatically detects the container's IP address and configures Tailsca
 
 ### Funnel Labels (Public Internet Access)
 
-Funnel exposes your service to the **public internet**. Independent from service labels.
+Funnel exposes your service to the **public internet**. It can be used together with a DockTail service or on its own for funnel-only containers.
 
 | Label | Required | Default | Description |
 |-------|----------|---------|-------------|
@@ -278,6 +278,8 @@ Funnel exposes your service to the **public internet**. Independent from service
 **Notes:**
 - Only ONE funnel per port (Tailscale limitation)
 - Uses machine hostname, not service name: `https://<machine>.<tailnet>.ts.net`
+- Funnel-only containers can omit `docktail.service.enable` and the other `docktail.service.*` labels entirely
+- `docktail.service.direct` and `docktail.service.network` still control how DockTail reaches the container backend for funnel traffic
 
 ## Examples
 
@@ -396,6 +398,21 @@ services:
 Access:
 - Tailnet: `https://website.your-tailnet.ts.net`
 - Public: `https://your-machine.your-tailnet.ts.net`
+
+### Funnel-Only Public Proxy
+
+```yaml
+services:
+  immich-public-proxy:
+    image: ghcr.io/immich-app/immich-public-proxy:latest
+    labels:
+      - "docktail.funnel.enable=true"
+      - "docktail.funnel.port=3000"
+      - "docktail.funnel.funnel-port=8443"
+```
+
+Access:
+- Public only: `https://your-machine.your-tailnet.ts.net:8443`
 
 ## Reference
 

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -205,6 +205,16 @@ services:
       - "docktail.funnel.enable=true"
       - "docktail.funnel.port=80"
 
+  # Funnel-only container on port 8443
+  test-funnel-only:
+    image: nginx:alpine
+    container_name: e2e-funnel-only
+    restart: "no"
+    labels:
+      - "docktail.funnel.enable=true"
+      - "docktail.funnel.port=80"
+      - "docktail.funnel.funnel-port=8443"
+
   # ============================================================================
   # 5. Custom Tags
   # ============================================================================

--- a/docker/client.go
+++ b/docker/client.go
@@ -357,9 +357,9 @@ func (c *Client) parseFunnelConfig(cctx *containerCtx, labels map[string]string)
 		}
 	}
 
-	validFunnelProtocols := map[string]bool{"https": true, "tcp": true, "tls-terminated-tcp": true}
+	validFunnelProtocols := map[string]bool{"http": true, "https": true, "tcp": true, "tls-terminated-tcp": true}
 	if !validFunnelProtocols[funnelProtocol] {
-		return nil, fmt.Errorf("invalid funnel protocol: %s (must be https, tcp, or tls-terminated-tcp)", funnelProtocol)
+		return nil, fmt.Errorf("invalid funnel protocol: %s (must be http, https, tcp, or tls-terminated-tcp)", funnelProtocol)
 	}
 
 	funnelDestIP, funnelTargetPort, err := c.resolveDestPort(cctx, funnelPort)

--- a/docker/client.go
+++ b/docker/client.go
@@ -73,19 +73,32 @@ func (c *Client) WatchEvents(ctx context.Context) (<-chan events.Message, <-chan
 	return eventsChan, errChan
 }
 
-// GetEnabledContainers returns all running containers with docktail.service.enable=true
+func isServiceEnabled(labels map[string]string) bool {
+	return labels[apptypes.LabelEnable] == "true"
+}
+
+func isFunnelEnabled(labels map[string]string) bool {
+	return labels[apptypes.LabelFunnelEnable] == "true"
+}
+
+func isManagedContainer(labels map[string]string) bool {
+	return isServiceEnabled(labels) || isFunnelEnabled(labels)
+}
+
+// GetEnabledContainers returns all running containers managed by DockTail.
+// A container can be managed by a Tailscale service, a funnel, or both.
 func (c *Client) GetEnabledContainers(ctx context.Context) ([]*apptypes.ContainerService, error) {
-	containers, err := c.cli.ContainerList(ctx, container.ListOptions{
-		Filters: filters.NewArgs(
-			filters.Arg("label", apptypes.LabelEnable+"=true"),
-		),
-	})
+	containers, err := c.cli.ContainerList(ctx, container.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list containers: %w", err)
 	}
 
 	var services []*apptypes.ContainerService
 	for _, cont := range containers {
+		if !isManagedContainer(cont.Labels) {
+			continue
+		}
+
 		parsed, err := c.parseContainer(ctx, cont.ID, cont.Labels)
 		if err != nil {
 			log.Warn().
@@ -303,34 +316,81 @@ func (c *Client) resolveDestPort(cctx *containerCtx, targetPort string) (string,
 	return "localhost", hostPort, nil
 }
 
-// parseContainer extracts service configuration from container labels.
-// Returns one ContainerService for the primary port plus one for each indexed port.
-func (c *Client) parseContainer(ctx context.Context, containerID string, labels map[string]string) ([]*apptypes.ContainerService, error) {
-	// Check if docktail is enabled
-	if labels[apptypes.LabelEnable] != "true" {
+type funnelConfig struct {
+	IPAddress  string
+	Port       string
+	TargetPort string
+	PublicPort string
+	Protocol   string
+}
+
+func (c *Client) parseFunnelConfig(cctx *containerCtx, labels map[string]string) (*funnelConfig, error) {
+	if !isFunnelEnabled(labels) {
 		return nil, nil
 	}
 
-	// Validate required labels
-	serviceName := labels[apptypes.LabelService]
-	if serviceName == "" {
-		return nil, fmt.Errorf("missing required label: %s", apptypes.LabelService)
+	funnelPort := labels[apptypes.LabelFunnelPort]
+	if funnelPort == "" {
+		return nil, fmt.Errorf("funnel enabled but missing required label: %s (container port)", apptypes.LabelFunnelPort)
 	}
 
-	targetPort := labels[apptypes.LabelTarget]
-	if targetPort == "" {
-		return nil, fmt.Errorf("missing required label: %s", apptypes.LabelTarget)
+	funnelProtocol := labels[apptypes.LabelFunnelProtocol]
+	if funnelProtocol == "" {
+		funnelProtocol = "https"
+		log.Debug().
+			Str("container", cctx.containerID[:12]).
+			Msg("Funnel protocol not specified, defaulting to HTTPS")
 	}
 
-	// Resolve protocols for the primary port
-	protocol, port, serviceProtocol, err := resolveProtocols(
-		containerID, targetPort,
-		labels[apptypes.LabelPort],
-		labels[apptypes.LabelServiceProtocol],
-		labels[apptypes.LabelTargetProtocol],
-	)
+	funnelFunnelPort := labels[apptypes.LabelFunnelFunnelPort]
+	if funnelFunnelPort == "" {
+		funnelFunnelPort = "443"
+		log.Debug().
+			Str("container", cctx.containerID[:12]).
+			Msg("Funnel public port not specified, defaulting to 443")
+	}
+
+	if funnelProtocol == "https" || funnelProtocol == "http" {
+		validFunnelPorts := map[string]bool{"443": true, "8443": true, "10000": true}
+		if !validFunnelPorts[funnelFunnelPort] {
+			return nil, fmt.Errorf("invalid funnel-port: %s for HTTPS/HTTP (must be 443, 8443, or 10000)", funnelFunnelPort)
+		}
+	}
+
+	validFunnelProtocols := map[string]bool{"https": true, "tcp": true, "tls-terminated-tcp": true}
+	if !validFunnelProtocols[funnelProtocol] {
+		return nil, fmt.Errorf("invalid funnel protocol: %s (must be https, tcp, or tls-terminated-tcp)", funnelProtocol)
+	}
+
+	funnelDestIP, funnelTargetPort, err := c.resolveDestPort(cctx, funnelPort)
 	if err != nil {
 		return nil, err
+	}
+
+	log.Info().
+		Str("container", cctx.containerName).
+		Str("funnel_container_port", funnelPort).
+		Str("funnel_host_port", funnelTargetPort).
+		Str("funnel_public_port", funnelFunnelPort).
+		Str("funnel_protocol", funnelProtocol).
+		Msg("Funnel enabled for public internet access")
+
+	return &funnelConfig{
+		IPAddress:  funnelDestIP,
+		Port:       funnelPort,
+		TargetPort: funnelTargetPort,
+		PublicPort: funnelFunnelPort,
+		Protocol:   funnelProtocol,
+	}, nil
+}
+
+// parseContainer extracts service configuration from container labels.
+// Returns one ContainerService for the primary port plus one for each indexed port.
+func (c *Client) parseContainer(ctx context.Context, containerID string, labels map[string]string) ([]*apptypes.ContainerService, error) {
+	serviceEnabled := isServiceEnabled(labels)
+	funnelEnabled := isFunnelEnabled(labels)
+	if !serviceEnabled && !funnelEnabled {
+		return nil, nil
 	}
 
 	// Get container details for port bindings
@@ -349,12 +409,6 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 		isHostNetwork:    inspect.HostConfig != nil && string(inspect.HostConfig.NetworkMode) == "host",
 		isNoNetwork:      inspect.HostConfig != nil && string(inspect.HostConfig.NetworkMode) == "none",
 		isDirectMode:     labels[apptypes.LabelDirect] != "false",
-	}
-
-	// Resolve destination for primary port
-	destIP, destPort, err := c.resolveDestPort(cctx, targetPort)
-	if err != nil {
-		return nil, err
 	}
 
 	// Parse tags
@@ -377,103 +431,89 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 		copy(tags, c.defaultTags)
 	}
 	cctx.tags = tags
-	cctx.destIP = destIP
 
-	// Parse funnel configuration (COMPLETELY INDEPENDENT of serve)
-	funnelEnabled := labels[apptypes.LabelFunnelEnable] == "true"
-	var funnelPort, funnelTargetPort, funnelFunnelPort, funnelProtocol string
-
-	if funnelEnabled {
-		funnelPort = labels[apptypes.LabelFunnelPort]
-		if funnelPort == "" {
-			return nil, fmt.Errorf("funnel enabled but missing required label: %s (container port)", apptypes.LabelFunnelPort)
+	var result []*apptypes.ContainerService
+	if serviceEnabled {
+		// Validate required labels
+		serviceName := labels[apptypes.LabelService]
+		if serviceName == "" {
+			return nil, fmt.Errorf("missing required label: %s", apptypes.LabelService)
 		}
 
-		funnelProtocol = labels[apptypes.LabelFunnelProtocol]
-		if funnelProtocol == "" {
-			funnelProtocol = "https"
-			log.Debug().
-				Str("container", containerID[:12]).
-				Msg("Funnel protocol not specified, defaulting to HTTPS")
+		targetPort := labels[apptypes.LabelTarget]
+		if targetPort == "" {
+			return nil, fmt.Errorf("missing required label: %s", apptypes.LabelTarget)
 		}
 
-		funnelFunnelPort = labels[apptypes.LabelFunnelFunnelPort]
-		if funnelFunnelPort == "" {
-			funnelFunnelPort = "443"
-			log.Debug().
-				Str("container", containerID[:12]).
-				Msg("Funnel public port not specified, defaulting to 443")
+		// Resolve protocols for the primary port
+		protocol, port, serviceProtocol, err := resolveProtocols(
+			containerID, targetPort,
+			labels[apptypes.LabelPort],
+			labels[apptypes.LabelServiceProtocol],
+			labels[apptypes.LabelTargetProtocol],
+		)
+		if err != nil {
+			return nil, err
 		}
 
-		if funnelProtocol == "https" || funnelProtocol == "http" {
-			validFunnelPorts := map[string]bool{"443": true, "8443": true, "10000": true}
-			if !validFunnelPorts[funnelFunnelPort] {
-				return nil, fmt.Errorf("invalid funnel-port: %s for HTTPS/HTTP (must be 443, 8443, or 10000)", funnelFunnelPort)
-			}
+		// Resolve destination for primary port
+		destIP, destPort, err := c.resolveDestPort(cctx, targetPort)
+		if err != nil {
+			return nil, err
 		}
+		cctx.destIP = destIP
 
-		validFunnelProtocols := map[string]bool{"https": true, "tcp": true, "tls-terminated-tcp": true}
-		if !validFunnelProtocols[funnelProtocol] {
-			return nil, fmt.Errorf("invalid funnel protocol: %s (must be https, tcp, or tls-terminated-tcp)", funnelProtocol)
+		primary := &apptypes.ContainerService{
+			ContainerID:     cctx.containerID[:12],
+			ContainerName:   cctx.containerName,
+			ServiceEnabled:  true,
+			ServiceName:     serviceName,
+			Port:            port,
+			TargetPort:      destPort,
+			ServiceProtocol: serviceProtocol,
+			Protocol:        protocol,
+			Tags:            tags,
+			IPAddress:       destIP,
 		}
+		result = append(result, primary)
 
-		if cctx.isHostNetwork {
-			funnelTargetPort = funnelPort
-		} else if cctx.isDirectMode {
-			funnelTargetPort = funnelPort
-		} else {
-			funnelPortKey := nat.Port(fmt.Sprintf("%s/tcp", funnelPort))
-			if cctx.inspect.HostConfig != nil && cctx.inspect.HostConfig.PortBindings != nil {
-				if bindings, ok := cctx.inspect.HostConfig.PortBindings[funnelPortKey]; ok && len(bindings) > 0 {
-					funnelTargetPort = bindings[0].HostPort
-				}
-			}
-			if funnelTargetPort == "" && cctx.inspect.NetworkSettings != nil && cctx.inspect.NetworkSettings.Ports != nil {
-				if bindings, ok := cctx.inspect.NetworkSettings.Ports[funnelPortKey]; ok && len(bindings) > 0 {
-					funnelTargetPort = bindings[0].HostPort
-				}
-			}
-			if funnelTargetPort == "" {
-				return nil, fmt.Errorf("funnel container port %s is NOT published to host (direct mode disabled). Add it to ports in docker-compose, or remove 'docktail.service.direct=false'", funnelPort)
-			}
+		// Parse indexed services (one container can define multiple separate Tailscale services)
+		indexedServices, err := c.parseIndexedPorts(cctx, labels, serviceName, port)
+		if err != nil {
+			return nil, err
 		}
-
-		log.Info().
-			Str("container", cctx.containerName).
-			Str("funnel_container_port", funnelPort).
-			Str("funnel_host_port", funnelTargetPort).
-			Str("funnel_public_port", funnelFunnelPort).
-			Str("funnel_protocol", funnelProtocol).
-			Msg("Funnel enabled for public internet access")
+		result = append(result, indexedServices...)
 	}
 
-	// Build primary service
-	primary := &apptypes.ContainerService{
-		ContainerID:      cctx.containerID[:12],
-		ContainerName:    cctx.containerName,
-		ServiceName:      serviceName,
-		Port:             port,
-		TargetPort:       destPort,
-		ServiceProtocol:  serviceProtocol,
-		Protocol:         protocol,
-		Tags:             tags,
-		IPAddress:        destIP,
-		FunnelEnabled:    funnelEnabled,
-		FunnelPort:       funnelPort,
-		FunnelTargetPort: funnelTargetPort,
-		FunnelFunnelPort: funnelFunnelPort,
-		FunnelProtocol:   funnelProtocol,
-	}
-
-	// Parse indexed services (one container can define multiple separate Tailscale services)
-	indexedServices, err := c.parseIndexedPorts(cctx, labels, serviceName, port)
+	funnelCfg, err := c.parseFunnelConfig(cctx, labels)
 	if err != nil {
 		return nil, err
 	}
+	if funnelCfg == nil {
+		return result, nil
+	}
 
-	result := make([]*apptypes.ContainerService, 0, 1+len(indexedServices))
-	result = append(result, primary)
-	result = append(result, indexedServices...)
+	if serviceEnabled {
+		result[0].FunnelEnabled = true
+		result[0].FunnelPort = funnelCfg.Port
+		result[0].FunnelTargetPort = funnelCfg.TargetPort
+		result[0].FunnelFunnelPort = funnelCfg.PublicPort
+		result[0].FunnelProtocol = funnelCfg.Protocol
+		return result, nil
+	}
+
+	result = append(result, &apptypes.ContainerService{
+		ContainerID:      cctx.containerID[:12],
+		ContainerName:    cctx.containerName,
+		ServiceEnabled:   false,
+		Tags:             tags,
+		IPAddress:        funnelCfg.IPAddress,
+		FunnelEnabled:    true,
+		FunnelPort:       funnelCfg.Port,
+		FunnelTargetPort: funnelCfg.TargetPort,
+		FunnelFunnelPort: funnelCfg.PublicPort,
+		FunnelProtocol:   funnelCfg.Protocol,
+	})
 
 	return result, nil
 }
@@ -591,6 +631,7 @@ func (c *Client) parseIndexedPorts(
 		svc := &apptypes.ContainerService{
 			ContainerID:     cctx.containerID[:12],
 			ContainerName:   cctx.containerName,
+			ServiceEnabled:  true,
 			ServiceName:     idxServiceName,
 			Port:            servicePort,
 			TargetPort:      idxDestPort,

--- a/docker/client_test.go
+++ b/docker/client_test.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"strconv"
 	"testing"
+
+	apptypes "github.com/marvinvr/docktail/types"
 )
 
 func TestResolveProtocols(t *testing.T) {
@@ -182,6 +184,55 @@ func TestResolveProtocols(t *testing.T) {
 			}
 			if serviceProtocol != tt.expectedServiceProtocol {
 				t.Errorf("serviceProtocol = %q, want %q", serviceProtocol, tt.expectedServiceProtocol)
+			}
+		})
+	}
+}
+
+func TestManagedContainerDetection(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		wantService bool
+		wantFunnel  bool
+		wantManaged bool
+	}{
+		{
+			name:        "service only container",
+			labels:      map[string]string{apptypes.LabelEnable: "true"},
+			wantService: true,
+			wantManaged: true,
+		},
+		{
+			name:        "funnel only container",
+			labels:      map[string]string{apptypes.LabelFunnelEnable: "true"},
+			wantFunnel:  true,
+			wantManaged: true,
+		},
+		{
+			name:        "service and funnel container",
+			labels:      map[string]string{apptypes.LabelEnable: "true", apptypes.LabelFunnelEnable: "true"},
+			wantService: true,
+			wantFunnel:  true,
+			wantManaged: true,
+		},
+		{
+			name:        "unmanaged container",
+			labels:      map[string]string{},
+			wantManaged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isServiceEnabled(tt.labels); got != tt.wantService {
+				t.Errorf("isServiceEnabled() = %v, want %v", got, tt.wantService)
+			}
+			if got := isFunnelEnabled(tt.labels); got != tt.wantFunnel {
+				t.Errorf("isFunnelEnabled() = %v, want %v", got, tt.wantFunnel)
+			}
+			if got := isManagedContainer(tt.labels); got != tt.wantManaged {
+				t.Errorf("isManagedContainer() = %v, want %v", got, tt.wantManaged)
 			}
 		})
 	}

--- a/e2e.sh
+++ b/e2e.sh
@@ -365,8 +365,13 @@ assert_service_protocol     "e2e-default-target443" "http"
 # ==============================================================================
 
 log "4. Funnel"
+echo "  --- service + funnel ---"
 assert_service_exists       "e2e-funnel"
 assert_funnel_active        "443"
+
+echo "  --- funnel only ---"
+assert_service_not_exists   "e2e-funnel-only"
+assert_funnel_active        "8443"
 
 # ==============================================================================
 # 5. Custom Tags

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -89,14 +89,28 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		Msg("Found enabled containers")
 
 	for _, container := range containers {
-		log.Debug().
+		event := log.Debug().
 			Str("container", container.ContainerName).
-			Str("service", container.ServiceName).
-			Str("ip", container.IPAddress).
-			Str("port", container.Port).
-			Str("target", container.TargetPort).
-			Str("protocol", container.Protocol).
-			Msg("Container configuration")
+			Bool("service_enabled", container.ServiceEnabled).
+			Bool("funnel_enabled", container.FunnelEnabled).
+			Str("ip", container.IPAddress)
+
+		if container.ServiceEnabled {
+			event = event.
+				Str("service", container.ServiceName).
+				Str("port", container.Port).
+				Str("target", container.TargetPort).
+				Str("protocol", container.Protocol)
+		}
+
+		if container.FunnelEnabled {
+			event = event.
+				Str("funnel_public_port", container.FunnelFunnelPort).
+				Str("funnel_target_port", container.FunnelTargetPort).
+				Str("funnel_protocol", container.FunnelProtocol)
+		}
+
+		event.Msg("Container configuration")
 	}
 
 	// Reconcile services using CLI commands

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -25,6 +25,7 @@ type Client struct {
 	httpClient      *http.Client
 	apiSyncEnabled  bool
 	serverVersion   string // set when CLI/daemon version mismatch detected
+	managedFunnels  map[string]struct{}
 	ignoredServices map[string]struct{}
 }
 
@@ -45,6 +46,7 @@ func NewClient(cfg ClientConfig) *Client {
 		socketPath:      cfg.SocketPath,
 		tailnet:         cfg.Tailnet,
 		baseURL:         "https://api.tailscale.com",
+		managedFunnels:  make(map[string]struct{}),
 		ignoredServices: make(map[string]struct{}),
 	}
 
@@ -509,11 +511,31 @@ func (c *Client) CleanupAllServices(ctx context.Context) error {
 			Int("funnel_count", len(currentFunnels)).
 			Msg("Found funnels to clean up")
 
-		if err := c.resetFunnels(ctx, "cleanup"); err != nil {
-			log.Error().Err(err).Msg("Failed to clean up funnels")
-			totalErrors = append(totalErrors, err)
+		ownedFunnels := make([]string, 0, len(currentFunnels))
+		unmanagedFunnels := make([]string, 0)
+		for publicPort := range currentFunnels {
+			if _, managed := c.managedFunnels[publicPort]; managed {
+				ownedFunnels = append(ownedFunnels, publicPort)
+			} else {
+				unmanagedFunnels = append(unmanagedFunnels, publicPort)
+			}
+		}
+
+		if len(ownedFunnels) == 0 {
+			log.Info().Msg("Skipping funnel cleanup: no current funnels are known to be managed by this DockTail process")
+		} else if len(unmanagedFunnels) > 0 {
+			log.Warn().
+				Strs("managed_public_ports", ownedFunnels).
+				Strs("unmanaged_public_ports", unmanagedFunnels).
+				Msg("Skipping funnel cleanup because unmanaged funnels exist on this node")
 		} else {
-			funnelsCleaned = len(currentFunnels)
+			if err := c.resetFunnels(ctx, "cleanup"); err != nil {
+				log.Error().Err(err).Msg("Failed to clean up funnels")
+				totalErrors = append(totalErrors, err)
+			} else {
+				funnelsCleaned = len(currentFunnels)
+				c.managedFunnels = make(map[string]struct{})
+			}
 		}
 	}
 

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -133,13 +133,23 @@ func (c *Client) ReconcileServices(ctx context.Context, desiredServices []*appty
 	// Re-detect version mismatch each cycle in case tailscaled was updated
 	c.DetectVersionMismatch(ctx)
 
+	serviceDesiredCount := 0
+	for _, svc := range desiredServices {
+		if svc.ServiceEnabled {
+			serviceDesiredCount++
+		}
+	}
+
 	log.Info().
-		Int("desired_count", len(desiredServices)).
+		Int("desired_count", serviceDesiredCount).
 		Msg("Starting service reconciliation using CLI commands")
 
 	// Build map of desired services for easy lookup
 	desiredMap := make(map[string]*apptypes.ContainerService)
 	for _, svc := range desiredServices {
+		if !svc.ServiceEnabled {
+			continue
+		}
 		key := fmt.Sprintf("svc:%s:%s", svc.ServiceName, svc.Port)
 		desiredMap[key] = svc
 	}
@@ -305,6 +315,9 @@ func (c *Client) syncServiceDefinitions(ctx context.Context, services []*apptype
 	uniqueServices := make(map[string]*serviceDef)
 
 	for _, svc := range services {
+		if !svc.ServiceEnabled {
+			continue
+		}
 		def, exists := uniqueServices[svc.ServiceName]
 		if !exists {
 			def = &serviceDef{Tags: svc.Tags}
@@ -485,6 +498,7 @@ func (c *Client) CleanupAllServices(ctx context.Context) error {
 	log.Info().Msg("Starting cleanup: removing all managed Tailscale services and funnels")
 
 	var totalErrors []error
+	funnelsCleaned := 0
 
 	// Cleanup funnels first (independent of services)
 	currentFunnels, err := c.getCurrentFunnels(ctx)
@@ -495,18 +509,11 @@ func (c *Client) CleanupAllServices(ctx context.Context) error {
 			Int("funnel_count", len(currentFunnels)).
 			Msg("Found funnels to clean up")
 
-		for _, port := range currentFunnels {
-			log.Info().
-				Str("public_port", port).
-				Msg("Cleaning up funnel")
-
-			if err := c.removeFunnel(ctx, "cleanup", port); err != nil {
-				log.Error().
-					Err(err).
-					Str("public_port", port).
-					Msg("Failed to clean up funnel")
-				totalErrors = append(totalErrors, err)
-			}
+		if err := c.resetFunnels(ctx, "cleanup"); err != nil {
+			log.Error().Err(err).Msg("Failed to clean up funnels")
+			totalErrors = append(totalErrors, err)
+		} else {
+			funnelsCleaned = len(currentFunnels)
 		}
 	}
 
@@ -563,7 +570,7 @@ func (c *Client) CleanupAllServices(ctx context.Context) error {
 	log.Info().
 		Int("services_cleaned", successCount).
 		Int("services_failed", failCount).
-		Int("funnels_cleaned", len(currentFunnels)-len(totalErrors)).
+		Int("funnels_cleaned", funnelsCleaned).
 		Int("total_errors", len(totalErrors)).
 		Msg("Cleanup completed")
 

--- a/tailscale/funnel.go
+++ b/tailscale/funnel.go
@@ -3,6 +3,7 @@ package tailscale
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -109,6 +110,14 @@ func currentFunnelMatchesDesired(current CurrentFunnel, svc *apptypes.ContainerS
 func isFunnelACLError(output string) bool {
 	return strings.Contains(output, "list of allowed nodes in the tailnet policy file does not include") ||
 		strings.Contains(output, "Funnel is enabled, but the list of allowed nodes")
+}
+
+func managedFunnelPortSet(ports map[string]struct{}) map[string]struct{} {
+	cloned := make(map[string]struct{}, len(ports))
+	for port := range ports {
+		cloned[port] = struct{}{}
+	}
+	return cloned
 }
 
 // getCurrentFunnels retrieves the current funnel status
@@ -247,25 +256,43 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 		return fmt.Errorf("funnel configuration error: %d containers have conflicting funnel-ports (only ONE funnel allowed per port)", len(duplicatePortErrors))
 	}
 
-	staleFunnels := make([]string, 0)
+	previouslyManaged := managedFunnelPortSet(c.managedFunnels)
+	staleManagedFunnels := make([]string, 0)
+	unmanagedCurrentFunnels := make([]string, 0)
+
 	for publicPort := range currentFunnels {
-		if _, exists := desiredFunnels[publicPort]; !exists {
-			staleFunnels = append(staleFunnels, publicPort)
+		if _, managed := previouslyManaged[publicPort]; managed {
+			if _, desired := desiredFunnels[publicPort]; !desired {
+				staleManagedFunnels = append(staleManagedFunnels, publicPort)
+			}
+			continue
 		}
+		unmanagedCurrentFunnels = append(unmanagedCurrentFunnels, publicPort)
 	}
 
-	if len(staleFunnels) > 0 {
-		log.Info().
-			Strs("public_ports", staleFunnels).
-			Msg("Resetting existing funnel configuration before applying desired state")
+	if len(staleManagedFunnels) > 0 {
+		if len(unmanagedCurrentFunnels) > 0 {
+			log.Warn().
+				Strs("stale_public_ports", staleManagedFunnels).
+				Strs("unmanaged_public_ports", unmanagedCurrentFunnels).
+				Msg("Skipping stale funnel cleanup because unmanaged funnels exist on this node")
+		} else {
+			log.Info().
+				Strs("public_ports", staleManagedFunnels).
+				Msg("Resetting DockTail-managed funnel configuration before applying desired state")
 
-		if err := c.resetFunnels(ctx, "reconcile"); err != nil {
-			return err
+			if err := c.resetFunnels(ctx, "reconcile"); err != nil {
+				return err
+			}
+			currentFunnels = make(map[string]CurrentFunnel)
+			previouslyManaged = make(map[string]struct{})
+			staleManagedFunnels = nil
 		}
-		currentFunnels = make(map[string]CurrentFunnel)
 	}
 
 	// Find funnels to add or update.
+	var applyErrors []error
+	successfulFunnels := make(map[string]struct{}, len(desiredFunnels)+len(staleManagedFunnels))
 	for publicPort, svc := range desiredFunnels {
 		current, exists := currentFunnels[publicPort]
 
@@ -274,6 +301,7 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 				Str("container", svc.ContainerName).
 				Str("public_port", svc.FunnelFunnelPort).
 				Msg("Funnel already configured correctly")
+			successfulFunnels[publicPort] = struct{}{}
 			continue
 		}
 
@@ -287,8 +315,20 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 				Err(err).
 				Str("container", svc.ContainerName).
 				Msg("Failed to enable funnel")
-			// Continue with other services
+			applyErrors = append(applyErrors, fmt.Errorf("%s:%s: %w", svc.ContainerName, publicPort, err))
+			continue
 		}
+
+		successfulFunnels[publicPort] = struct{}{}
+	}
+
+	for _, publicPort := range staleManagedFunnels {
+		successfulFunnels[publicPort] = struct{}{}
+	}
+	c.managedFunnels = successfulFunnels
+
+	if len(applyErrors) > 0 {
+		return fmt.Errorf("failed to enable %d funnel(s): %w", len(applyErrors), errors.Join(applyErrors...))
 	}
 
 	return nil

--- a/tailscale/funnel.go
+++ b/tailscale/funnel.go
@@ -27,17 +27,108 @@ type FunnelHandler struct {
 	Proxy string `json:"Proxy"`
 }
 
+type CurrentFunnel struct {
+	PublicPort  string
+	Protocol    string
+	Destination string
+}
+
+func extractPort(value string) string {
+	idx := strings.LastIndex(value, ":")
+	if idx == -1 || idx == len(value)-1 {
+		return ""
+	}
+	return value[idx+1:]
+}
+
+func detectFunnelProtocol(config map[string]bool) string {
+	for key, enabled := range config {
+		if !enabled {
+			continue
+		}
+
+		normalized := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(key, "_", "-"), " ", "-"))
+		switch {
+		case strings.Contains(normalized, "tls") && strings.Contains(normalized, "tcp"):
+			return "tls-terminated-tcp"
+		case strings.Contains(normalized, "https") || strings.Contains(normalized, "http"):
+			return "https"
+		case strings.Contains(normalized, "tcp"):
+			return "tcp"
+		}
+	}
+
+	return ""
+}
+
+func firstProxy(config FunnelWebConfig) string {
+	for _, handler := range config.Handlers {
+		if handler.Proxy != "" {
+			return handler.Proxy
+		}
+	}
+	return ""
+}
+
+func normalizeDesiredFunnelProtocol(protocol string) string {
+	if protocol == "http" {
+		return "https"
+	}
+	return protocol
+}
+
+func desiredFunnelDestination(svc *apptypes.ContainerService) string {
+	switch svc.FunnelProtocol {
+	case "tcp", "tls-terminated-tcp":
+		return fmt.Sprintf("tcp://%s:%s", svc.IPAddress, svc.FunnelTargetPort)
+	default:
+		return fmt.Sprintf("http://%s:%s", svc.IPAddress, svc.FunnelTargetPort)
+	}
+}
+
+func currentFunnelMatchesDesired(current CurrentFunnel, svc *apptypes.ContainerService) bool {
+	if current.PublicPort == "" {
+		return false
+	}
+
+	if current.Protocol == "" && current.Destination == "" {
+		return false
+	}
+
+	if current.Protocol != "" && current.Protocol != normalizeDesiredFunnelProtocol(svc.FunnelProtocol) {
+		return false
+	}
+
+	if current.Destination != "" && current.Destination != desiredFunnelDestination(svc) {
+		return false
+	}
+
+	return true
+}
+
+func isFunnelACLError(output string) bool {
+	return strings.Contains(output, "list of allowed nodes in the tailnet policy file does not include") ||
+		strings.Contains(output, "Funnel is enabled, but the list of allowed nodes")
+}
+
 // getCurrentFunnels retrieves the current funnel status
-// Returns a map where the value is the port (e.g., "443") for cleanup
-func (c *Client) getCurrentFunnels(ctx context.Context) (map[string]string, error) {
+// Returns a map keyed by public port (for example "443").
+func (c *Client) getCurrentFunnels(ctx context.Context) (map[string]CurrentFunnel, error) {
 	cmd := c.tailscaleCmd(ctx, "funnel", "status", "--json")
 	output, err := cmd.CombinedOutput()
 
-	// Funnel status command doesn't exist or no funnels configured
-	// This is expected when funnel isn't being used
-	if err != nil || len(output) == 0 {
+	if err != nil {
+		outputStr := string(output)
+		if len(outputStr) == 0 || isNotFoundError(outputStr) {
+			log.Debug().Msg("No funnels configured (this is normal if funnel is not in use)")
+			return make(map[string]CurrentFunnel), nil
+		}
+		return nil, fmt.Errorf("failed to get funnel status: %w\nOutput: %s", err, outputStr)
+	}
+
+	if len(output) == 0 {
 		log.Debug().Msg("No funnels configured (this is normal if funnel is not in use)")
-		return make(map[string]string), nil
+		return make(map[string]CurrentFunnel), nil
 	}
 
 	// Strip warnings from output (like we do for serve status)
@@ -46,30 +137,56 @@ func (c *Client) getCurrentFunnels(ctx context.Context) (map[string]string, erro
 	// Check if output indicates no funnels (before trying to parse JSON)
 	if isNotFoundError(outputStr) || len(outputStr) == 0 || outputStr == "\n" {
 		log.Debug().Msg("No existing funnels found")
-		return make(map[string]string), nil
+		return make(map[string]CurrentFunnel), nil
 	}
 
 	// Parse JSON output
 	var status FunnelStatus
 	if err := json.Unmarshal([]byte(outputStr), &status); err != nil {
 		log.Warn().Err(err).Str("output", outputStr).Msg("Failed to parse funnel status JSON, assuming no funnels")
-		return make(map[string]string), nil
+		return make(map[string]CurrentFunnel), nil
 	}
 
-	// Extract ports from AllowFunnel section
-	// Format: "hostname.tailnet.ts.net:443" -> true
-	funnels := make(map[string]string)
+	funnels := make(map[string]CurrentFunnel)
 	for hostPort := range status.AllowFunnel {
-		// Extract port from "hostname.tailnet.ts.net:443"
-		parts := strings.Split(hostPort, ":")
-		if len(parts) == 2 {
-			port := parts[1]
-			funnels[hostPort] = port
-			log.Debug().
-				Str("host_port", hostPort).
-				Str("port", port).
-				Msg("Detected active funnel")
+		port := extractPort(hostPort)
+		if port == "" {
+			continue
 		}
+
+		current := funnels[port]
+		current.PublicPort = port
+		current.Protocol = detectFunnelProtocol(status.TCP[port])
+		funnels[port] = current
+
+		log.Debug().
+			Str("host_port", hostPort).
+			Str("port", port).
+			Msg("Detected active funnel")
+	}
+
+	for port, tcpConfig := range status.TCP {
+		current := funnels[port]
+		current.PublicPort = port
+		if current.Protocol == "" {
+			current.Protocol = detectFunnelProtocol(tcpConfig)
+		}
+		funnels[port] = current
+	}
+
+	for webKey, webConfig := range status.Web {
+		port := extractPort(webKey)
+		if port == "" {
+			continue
+		}
+
+		current := funnels[port]
+		current.PublicPort = port
+		if current.Protocol == "" {
+			current.Protocol = "https"
+		}
+		current.Destination = firstProxy(webConfig)
+		funnels[port] = current
 	}
 
 	log.Debug().
@@ -90,7 +207,7 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 	currentFunnels, err := c.getCurrentFunnels(ctx)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to get current funnels, will proceed with desired state")
-		currentFunnels = make(map[string]string) // service:port -> port
+		currentFunnels = make(map[string]CurrentFunnel)
 	}
 
 	// Build map of desired funnels and check for duplicate funnel-ports
@@ -101,7 +218,7 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 
 	for _, svc := range desiredServices {
 		if svc.FunnelEnabled {
-			key := fmt.Sprintf("svc:%s", svc.ServiceName)
+			key := svc.FunnelFunnelPort
 			desiredFunnels[key] = svc
 
 			// Check for duplicate funnel-port usage
@@ -130,67 +247,47 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 		return fmt.Errorf("funnel configuration error: %d containers have conflicting funnel-ports (only ONE funnel allowed per port)", len(duplicatePortErrors))
 	}
 
-	// Find funnels to add
-	for serviceName, svc := range desiredFunnels {
-		currentPort, exists := currentFunnels[serviceName]
+	staleFunnels := make([]string, 0)
+	for publicPort := range currentFunnels {
+		if _, exists := desiredFunnels[publicPort]; !exists {
+			staleFunnels = append(staleFunnels, publicPort)
+		}
+	}
 
-		if !exists || currentPort != svc.FunnelFunnelPort {
-			// Funnel doesn't exist or port changed - add/update it
-			if exists {
-				// Remove old funnel first if port changed
-				log.Info().
-					Str("container", svc.ContainerName).
-					Str("old_public_port", currentPort).
-					Str("new_public_port", svc.FunnelFunnelPort).
-					Msg("Funnel port changed, updating")
-				if err := c.removeFunnel(ctx, svc.ContainerName, currentPort); err != nil {
-					log.Error().Err(err).Str("container", svc.ContainerName).Msg("Failed to remove old funnel")
-				}
-			}
+	if len(staleFunnels) > 0 {
+		log.Info().
+			Strs("public_ports", staleFunnels).
+			Msg("Resetting existing funnel configuration before applying desired state")
 
-			log.Info().
-				Str("container", svc.ContainerName).
-				Str("public_port", svc.FunnelFunnelPort).
-				Msg("Enabling funnel")
+		if err := c.resetFunnels(ctx, "reconcile"); err != nil {
+			return err
+		}
+		currentFunnels = make(map[string]CurrentFunnel)
+	}
 
-			if err := c.addFunnel(ctx, svc); err != nil {
-				log.Error().
-					Err(err).
-					Str("container", svc.ContainerName).
-					Msg("Failed to enable funnel")
-				// Continue with other services
-			}
-		} else {
+	// Find funnels to add or update.
+	for publicPort, svc := range desiredFunnels {
+		current, exists := currentFunnels[publicPort]
+
+		if exists && currentFunnelMatchesDesired(current, svc) {
 			log.Debug().
 				Str("container", svc.ContainerName).
 				Str("public_port", svc.FunnelFunnelPort).
 				Msg("Funnel already configured correctly")
-		}
-	}
-
-	// Find funnels to remove (in current but not in desired)
-	// Note: We track by public port (funnel-port) since funnel doesn't use service names
-	for _, port := range currentFunnels {
-		portInUse := false
-		for _, svc := range desiredFunnels {
-			if svc.FunnelFunnelPort == port {
-				portInUse = true
-				break
-			}
+			continue
 		}
 
-		if !portInUse {
-			log.Info().
-				Str("public_port", port).
-				Msg("Disabling funnel (no longer desired)")
+		log.Info().
+			Str("container", svc.ContainerName).
+			Str("public_port", svc.FunnelFunnelPort).
+			Msg("Enabling funnel")
 
-			if err := c.removeFunnel(ctx, "unknown", port); err != nil {
-				log.Error().
-					Err(err).
-					Str("public_port", port).
-					Msg("Failed to disable funnel")
-				// Continue with other services
-			}
+		if err := c.addFunnel(ctx, svc); err != nil {
+			log.Error().
+				Err(err).
+				Str("container", svc.ContainerName).
+				Msg("Failed to enable funnel")
+			// Continue with other services
 		}
 	}
 
@@ -206,7 +303,7 @@ func (c *Client) addFunnel(ctx context.Context, svc *apptypes.ContainerService) 
 	}
 
 	// Build destination using funnel's own target port
-	funnelDestination := fmt.Sprintf("http://%s:%s", svc.IPAddress, svc.FunnelTargetPort)
+	funnelDestination := desiredFunnelDestination(svc)
 
 	var cmd *exec.Cmd
 
@@ -247,7 +344,37 @@ func (c *Client) addFunnel(ctx context.Context, svc *apptypes.ContainerService) 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		stderr := string(output)
+		if isFunnelACLError(stderr) {
+			return fmt.Errorf(
+				"failed to enable funnel: this node is not allowed by your Tailscale funnel policy.\n"+
+					"Add the node to the allowed funnel nodes in your tailnet policy, then retry.\n"+
+					"Output: %s",
+				stderr,
+			)
+		}
 		return fmt.Errorf("failed to enable funnel: %w\nOutput: %s", err, stderr)
+	}
+
+	currentFunnels, verifyErr := c.getCurrentFunnels(ctx)
+	if verifyErr != nil {
+		return fmt.Errorf("funnel command succeeded but status verification failed: %w", verifyErr)
+	}
+
+	current, exists := currentFunnels[svc.FunnelFunnelPort]
+	if !exists || !currentFunnelMatchesDesired(current, svc) {
+		stderr := string(output)
+		if isFunnelACLError(stderr) {
+			return fmt.Errorf(
+				"tailscale funnel command completed but the funnel was not created because this node is not allowed by your Tailscale funnel policy.\n"+
+					"Add the node to the allowed funnel nodes in your tailnet policy, then retry.\n"+
+					"Output: %s",
+				stderr,
+			)
+		}
+		return fmt.Errorf(
+			"tailscale funnel command completed but the requested public port %s is not active.\nOutput: %s",
+			svc.FunnelFunnelPort, stderr,
+		)
 	}
 
 	log.Info().
@@ -259,23 +386,17 @@ func (c *Client) addFunnel(ctx context.Context, svc *apptypes.ContainerService) 
 	return nil
 }
 
-// removeFunnel disables Tailscale Funnel using reset
-// This removes ALL public internet access (funnel is independent of serve and service names)
-// Note: tailscale funnel reset removes ALL funnel configs, not just a specific port
-func (c *Client) removeFunnel(ctx context.Context, containerName string, port string) error {
+// resetFunnels clears all machine-level funnel configuration.
+func (c *Client) resetFunnels(ctx context.Context, reason string) error {
 	log.Info().
-		Str("container", containerName).
-		Str("port", port).
-		Msg("Disabling funnel - removing public internet access")
+		Str("reason", reason).
+		Msg("Resetting funnel configuration")
 
-	// Command: tailscale funnel reset
-	// Note: This resets ALL funnel configuration, not just one port
 	cmd := c.tailscaleCmd(ctx, "funnel", "reset")
 
 	log.Debug().
 		Str("command", cmd.String()).
-		Str("container", containerName).
-		Str("port", port).
+		Str("reason", reason).
 		Msg("Executing tailscale funnel reset command")
 
 	output, err := cmd.CombinedOutput()
@@ -284,18 +405,16 @@ func (c *Client) removeFunnel(ctx context.Context, containerName string, port st
 		// Ignore errors if funnel doesn't exist
 		if isNotFoundError(stderr) {
 			log.Debug().
-				Str("container", containerName).
-				Str("port", port).
-				Msg("Funnel doesn't exist, nothing to remove")
+				Str("reason", reason).
+				Msg("Funnel doesn't exist, nothing to reset")
 			return nil
 		}
-		return fmt.Errorf("failed to disable funnel: %w\nOutput: %s", err, stderr)
+		return fmt.Errorf("failed to reset funnels: %w\nOutput: %s", err, stderr)
 	}
 
 	log.Info().
-		Str("container", containerName).
-		Str("port", port).
-		Msg("Funnel disabled successfully")
+		Str("reason", reason).
+		Msg("Funnel configuration reset successfully")
 
 	return nil
 }

--- a/tailscale/funnel.go
+++ b/tailscale/funnel.go
@@ -285,7 +285,6 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 				return err
 			}
 			currentFunnels = make(map[string]CurrentFunnel)
-			previouslyManaged = make(map[string]struct{})
 			staleManagedFunnels = nil
 		}
 	}

--- a/tailscale/service_test.go
+++ b/tailscale/service_test.go
@@ -3,6 +3,8 @@ package tailscale
 import (
 	"encoding/json"
 	"testing"
+
+	apptypes "github.com/marvinvr/docktail/types"
 )
 
 func TestTailscaleStatusParsing(t *testing.T) {
@@ -235,6 +237,109 @@ func TestFunnelStatusParsing(t *testing.T) {
 			}
 			if tt.checkFunc != nil {
 				tt.checkFunc(t, status)
+			}
+		})
+	}
+}
+
+func TestCurrentFunnelMatchesDesired(t *testing.T) {
+	desired := &apptypes.ContainerService{
+		IPAddress:        "172.22.0.13",
+		FunnelTargetPort: "3000",
+		FunnelFunnelPort: "8443",
+		FunnelProtocol:   "https",
+	}
+
+	tests := []struct {
+		name    string
+		current CurrentFunnel
+		want    bool
+	}{
+		{
+			name: "matching https funnel",
+			current: CurrentFunnel{
+				PublicPort:  "8443",
+				Protocol:    "https",
+				Destination: "http://172.22.0.13:3000",
+			},
+			want: true,
+		},
+		{
+			name: "mismatched destination",
+			current: CurrentFunnel{
+				PublicPort:  "8443",
+				Protocol:    "https",
+				Destination: "http://172.22.0.13:8080",
+			},
+			want: false,
+		},
+		{
+			name: "mismatched protocol",
+			current: CurrentFunnel{
+				PublicPort:  "8443",
+				Protocol:    "tcp",
+				Destination: "tcp://172.22.0.13:3000",
+			},
+			want: false,
+		},
+		{
+			name: "unknown destination but matching protocol",
+			current: CurrentFunnel{
+				PublicPort: "8443",
+				Protocol:   "https",
+			},
+			want: true,
+		},
+		{
+			name: "missing state details forces reapply",
+			current: CurrentFunnel{
+				PublicPort: "8443",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := currentFunnelMatchesDesired(tt.current, desired); got != tt.want {
+				t.Errorf("currentFunnelMatchesDesired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectFunnelProtocol(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]bool
+		expect string
+	}{
+		{
+			name:   "https config",
+			input:  map[string]bool{"HTTPS": true},
+			expect: "https",
+		},
+		{
+			name:   "tcp config",
+			input:  map[string]bool{"TCP": true},
+			expect: "tcp",
+		},
+		{
+			name:   "tls terminated tcp config",
+			input:  map[string]bool{"TLS_TERMINATED_TCP": true},
+			expect: "tls-terminated-tcp",
+		},
+		{
+			name:   "empty config",
+			input:  map[string]bool{},
+			expect: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectFunnelProtocol(tt.input); got != tt.expect {
+				t.Errorf("detectFunnelProtocol() = %q, want %q", got, tt.expect)
 			}
 		})
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -4,6 +4,7 @@ package types
 type ContainerService struct {
 	ContainerID      string
 	ContainerName    string
+	ServiceEnabled   bool
 	ServiceName      string
 	Port             string   // Tailscale service port (e.g., "443")
 	TargetPort       string   // Container/host port to proxy to (e.g., "9080")


### PR DESCRIPTION
## Summary
- allow DockTail to manage containers that only define funnel labels without requiring a Tailscale service on the same container
- keep service reconciliation scoped to service-enabled entries while reconciling funnels independently by public port
- verify funnel creation after applying it and surface funnel ACL failures with clearer loggable errors

## Verification
- go build ./...

closes: #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for funnel-only containers as standalone public proxies (example and access URL added)
  * Services and funnels can be enabled independently

* **Documentation**
  * Clarified Funnel label behavior and added funnel-only YAML example

* **Improvements**
  * More robust funnel reconciliation, ownership tracking and bulk reset/cleanup
  * Better post-creation verification and ACL/policy error reporting
  * Conditional per-container logging

* **Tests**
  * New unit and e2e tests for service/funnel combinations and funnel behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->