### PR TITLE
Update 05-examples.md

### DIFF
--- a/docs/05-examples.md
+++ b/docs/05-examples.md
@@ -36,17 +36,17 @@ Access it at `https://api.your-tailnet.ts.net`.
 ```yaml
 services:
   forgejo:
-  image: codeberg.org/forgejo/forgejo:latest
-  labels:
-      - "docktail.service.enable=true"
-      - "docktail.service.name=forgejo"
-      - "docktail.service.port=3000"
-      - "docktail.service.service-port=443"
-      - "docktail.service.1.enable=true"
-      - "docktail.service.1.name=forgejo"
-      - "docktail.service.1.port=2222"
-      - "docktail.service.1.protocol=tcp"
-      - "docktail.service.1.service-port=22"
+    image: codeberg.org/forgejo/forgejo:latest
+    labels:
+        - "docktail.service.enable=true"
+        - "docktail.service.name=forgejo"
+        - "docktail.service.port=3000"
+        - "docktail.service.service-port=443"
+        - "docktail.service.1.enable=true"
+        - "docktail.service.1.name=forgejo"
+        - "docktail.service.1.port=2222"
+        - "docktail.service.1.protocol=tcp"
+        - "docktail.service.1.service-port=22"
 ```
 
 Access 

--- a/docs/05-examples.md
+++ b/docs/05-examples.md
@@ -31,6 +31,28 @@ services:
 
 Access it at `https://api.your-tailnet.ts.net`.
 
+### HTTPS with TCP (SSH)
+
+```yaml
+services:
+  forgejo:
+  image: codeberg.org/forgejo/forgejo:latest
+  labels:
+      - "docktail.service.enable=true"
+      - "docktail.service.name=forgejo"
+      - "docktail.service.port=3000"
+      - "docktail.service.service-port=443"
+      - "docktail.service.1.enable=true"
+      - "docktail.service.1.name=forgejo"
+      - "docktail.service.1.port=2222"
+      - "docktail.service.1.protocol=tcp"
+      - "docktail.service.1.service-port=22"
+```
+
+Access 
+- https at `https://forgejo.your-tailnet.ts.net` 
+- ssh at `ssh -T git@forgejo.your-tailnet.ts.net`
+
 ### Database Over TCP
 
 ```yaml


### PR DESCRIPTION
Add example for multiple services

Resolves https://github.com/marvinvr/docktail/issues/50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new example showing how to expose Forgejo over HTTPS while routing SSH via a separate TCP endpoint.
  * Updated access instructions to include both the HTTPS URL and the SSH command for connecting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->