### PR TITLE
Add file-backed credential env support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,14 @@ TAILSCALE_AUTH_KEY=tskey-auth-xxxxx
 # Required scope: "all". Couldn't figure out a reduced scope that actually works, am open to suggestions though.
 TAILSCALE_OAUTH_CLIENT_ID=
 TAILSCALE_OAUTH_CLIENT_SECRET=
+# Or point to mounted secret files instead:
+# FILE__TAILSCALE_OAUTH_CLIENT_ID=/run/secrets/docktail/tailscale_oauth_client_id
+# TAILSCALE_OAUTH_CLIENT_SECRET_FILE=/run/secrets/docktail/tailscale_oauth_client_secret
 
 # Option 2: API Key (expires every 90 days)
 # Generate at: https://login.tailscale.com/admin/settings/keys
 TAILSCALE_API_KEY=tskey-api-xxxxx
+# Or: TAILSCALE_API_KEY_FILE=/run/secrets/docktail/tailscale_api_key
 
 # Note: If both OAuth and API key are set, OAuth takes precedence
 

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ go.work.sum
 
 # env file
 .env
+.e2e-secrets/
 
 # Generated website documentation
 website/docs/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ curl http://myapp.your-tailnet.ts.net
 
 This assumes the Docker host is connected to Tailscale and allowed to advertise services. See the full docs for host setup, sidecar setup, OAuth permissions, ACLs, labels, Funnel, and examples.
 
+For Docker secrets or other mounted secret files, set `FILE__TAILSCALE_OAUTH_CLIENT_ID` / `FILE__TAILSCALE_OAUTH_CLIENT_SECRET` or `TAILSCALE_OAUTH_CLIENT_ID_FILE` / `TAILSCALE_OAUTH_CLIENT_SECRET_FILE` to the mounted file paths instead of putting the values directly in the environment.
+
 ## Common Examples
 
 Expose an app with Tailscale HTTPS:

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -38,13 +38,14 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ts-socket:/var/run/tailscale
+      - ./.e2e-secrets:/run/secrets/docktail:ro
     environment:
       - LOG_LEVEL=debug
       - RECONCILE_INTERVAL=5s
       - DEFAULT_SERVICE_TAGS=tag:ci-test-container
       - IGNORE_SERVICE_NAMES=e2e-manual-protected
-      - TAILSCALE_OAUTH_CLIENT_ID=${TS_OAUTH_CLIENT_ID:-}
-      - TAILSCALE_OAUTH_CLIENT_SECRET=${TS_OAUTH_CLIENT_SECRET:-}
+      - FILE__TAILSCALE_OAUTH_CLIENT_ID=/run/secrets/docktail/tailscale_oauth_client_id
+      - TAILSCALE_OAUTH_CLIENT_SECRET_FILE=/run/secrets/docktail/tailscale_oauth_client_secret
       - TAILSCALE_TAILNET=${TS_TAILNET:-}
 
   # ============================================================================

--- a/docs/03-tailscale-admin.md
+++ b/docs/03-tailscale-admin.md
@@ -20,6 +20,18 @@ environment:
   - TAILSCALE_OAUTH_CLIENT_SECRET=your-client-secret
 ```
 
+Or mount the credentials as files:
+
+```yaml
+services:
+  docktail:
+    volumes:
+      - ./secrets:/run/secrets/docktail:ro
+    environment:
+      - FILE__TAILSCALE_OAUTH_CLIENT_ID=/run/secrets/docktail/tailscale_oauth_client_id
+      - TAILSCALE_OAUTH_CLIENT_SECRET_FILE=/run/secrets/docktail/tailscale_oauth_client_secret
+```
+
 If OAuth and API key credentials are both configured, DockTail uses OAuth.
 
 ### API Key
@@ -30,6 +42,8 @@ An API key also enables automatic service creation, but Tailscale API keys expir
 environment:
   - TAILSCALE_API_KEY=tskey-api-...
 ```
+
+API keys can also be loaded from `FILE__TAILSCALE_API_KEY` or `TAILSCALE_API_KEY_FILE`.
 
 ### Manual Mode
 

--- a/docs/06-reference.md
+++ b/docs/06-reference.md
@@ -19,6 +19,16 @@ Use this section when checking exact configuration names, defaults, and supporte
 
 If both OAuth and API key credentials are configured, DockTail uses OAuth.
 
+Sensitive credential variables can also be loaded from files. This is useful with Docker secrets, Swarm secrets, and other secret mounts. Direct environment variables take precedence; when the direct variable is unset, DockTail checks `FILE__VARIABLE_NAME` first and `VARIABLE_NAME_FILE` second. The file content is used as the value with trailing newlines removed.
+
+Supported file-backed credential variables:
+
+| Direct variable | File variable alternatives |
+| --- | --- |
+| `TAILSCALE_OAUTH_CLIENT_ID` | `FILE__TAILSCALE_OAUTH_CLIENT_ID`, `TAILSCALE_OAUTH_CLIENT_ID_FILE` |
+| `TAILSCALE_OAUTH_CLIENT_SECRET` | `FILE__TAILSCALE_OAUTH_CLIENT_SECRET`, `TAILSCALE_OAUTH_CLIENT_SECRET_FILE` |
+| `TAILSCALE_API_KEY` | `FILE__TAILSCALE_API_KEY`, `TAILSCALE_API_KEY_FILE` |
+
 `IGNORE_SERVICE_NAMES` accepts bare names like `grafana` and fully qualified names like `svc:grafana`.
 
 ### Supported Protocols

--- a/e2e.sh
+++ b/e2e.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 COMPOSE_FILE="docker-compose.e2e.yaml"
+E2E_SECRETS_DIR=".e2e-secrets"
 TS_CONTAINER="e2e-tailscale"
 DOCKTAIL_CONTAINER="e2e-docktail"
 MAX_WAIT=120
@@ -27,6 +28,7 @@ cleanup() {
     log "Cleaning up"
     kill "$TIMEOUT_PID" 2>/dev/null || true
     docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+    rm -rf "$E2E_SECRETS_DIR"
 }
 trap cleanup EXIT
 
@@ -78,6 +80,13 @@ else
     echo "ERROR: Either TS_AUTHKEY or TS_OAUTH_CLIENT_ID + TS_OAUTH_CLIENT_SECRET is required"
     exit 1
 fi
+
+mkdir -p "$E2E_SECRETS_DIR"
+chmod 700 "$E2E_SECRETS_DIR"
+printf '%s\n' "${TS_OAUTH_CLIENT_ID:-}" > "$E2E_SECRETS_DIR/tailscale_oauth_client_id"
+printf '%s\n' "${TS_OAUTH_CLIENT_SECRET:-}" > "$E2E_SECRETS_DIR/tailscale_oauth_client_secret"
+chmod 600 "$E2E_SECRETS_DIR/tailscale_oauth_client_id" "$E2E_SECRETS_DIR/tailscale_oauth_client_secret"
+echo "  DockTail OAuth credentials prepared as file-backed secrets"
 
 # ==============================================================================
 # Helpers

--- a/main.go
+++ b/main.go
@@ -29,9 +29,9 @@ func main() {
 	tailscaleSocket := getEnv("TAILSCALE_SOCKET", "/var/run/tailscale/tailscaled.sock")
 
 	// Control Plane Configuration
-	tailscaleAPIKey := getEnv("TAILSCALE_API_KEY", "")
-	tailscaleOAuthClientID := getEnv("TAILSCALE_OAUTH_CLIENT_ID", "")
-	tailscaleOAuthClientSecret := getEnv("TAILSCALE_OAUTH_CLIENT_SECRET", "")
+	tailscaleAPIKey := getSecretEnv("TAILSCALE_API_KEY", "")
+	tailscaleOAuthClientID := getSecretEnv("TAILSCALE_OAUTH_CLIENT_ID", "")
+	tailscaleOAuthClientSecret := getSecretEnv("TAILSCALE_OAUTH_CLIENT_SECRET", "")
 	tailscaleTailnet := getEnv("TAILSCALE_TAILNET", "-")
 	defaultTagsStr := getEnv("DEFAULT_SERVICE_TAGS", "tag:container")
 	ignoreServiceNamesStr := getEnv("IGNORE_SERVICE_NAMES", "")
@@ -168,6 +168,40 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+func getSecretEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+
+	for _, fileKey := range []string{"FILE__" + key, key + "_FILE"} {
+		value, ok := getEnvFileValue(fileKey)
+		if ok {
+			return value
+		}
+	}
+
+	return defaultValue
+}
+
+func getEnvFileValue(fileKey string) (string, bool) {
+	path := strings.TrimSpace(os.Getenv(fileKey))
+	if path == "" {
+		return "", false
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal().
+			Err(err).
+			Str("file_env", fileKey).
+			Str("path", path).
+			Msg("Failed to read environment variable file")
+		return "", true
+	}
+
+	return strings.TrimRight(string(content), "\r\n"), true
 }
 
 func getEnvDuration(key string, defaultValue time.Duration) time.Duration {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetSecretEnvUsesDirectEnvFirst(t *testing.T) {
+	clearSecretEnv(t, "TAILSCALE_OAUTH_CLIENT_SECRET")
+	t.Setenv("TAILSCALE_OAUTH_CLIENT_SECRET", "from-env")
+	t.Setenv("FILE__TAILSCALE_OAUTH_CLIENT_SECRET", writeTestSecretFile(t, "from-file"))
+
+	value := getSecretEnv("TAILSCALE_OAUTH_CLIENT_SECRET", "")
+	if value != "from-env" {
+		t.Fatalf("expected direct env value, got %q", value)
+	}
+}
+
+func TestGetSecretEnvSupportsFilePrefix(t *testing.T) {
+	clearSecretEnv(t, "TAILSCALE_OAUTH_CLIENT_SECRET")
+	t.Setenv("FILE__TAILSCALE_OAUTH_CLIENT_SECRET", writeTestSecretFile(t, "from-file\n"))
+
+	value := getSecretEnv("TAILSCALE_OAUTH_CLIENT_SECRET", "")
+	if value != "from-file" {
+		t.Fatalf("expected FILE__ value with newline trimmed, got %q", value)
+	}
+}
+
+func TestGetSecretEnvSupportsFileSuffix(t *testing.T) {
+	clearSecretEnv(t, "TAILSCALE_OAUTH_CLIENT_SECRET")
+	t.Setenv("TAILSCALE_OAUTH_CLIENT_SECRET_FILE", writeTestSecretFile(t, "from-suffix\r\n"))
+
+	value := getSecretEnv("TAILSCALE_OAUTH_CLIENT_SECRET", "")
+	if value != "from-suffix" {
+		t.Fatalf("expected _FILE value with newline trimmed, got %q", value)
+	}
+}
+
+func TestGetSecretEnvUsesDefaultWhenUnset(t *testing.T) {
+	clearSecretEnv(t, "TAILSCALE_OAUTH_CLIENT_SECRET")
+
+	value := getSecretEnv("TAILSCALE_OAUTH_CLIENT_SECRET", "default")
+	if value != "default" {
+		t.Fatalf("expected default value, got %q", value)
+	}
+}
+
+func clearSecretEnv(t *testing.T, key string) {
+	t.Helper()
+
+	t.Setenv(key, "")
+	t.Setenv("FILE__"+key, "")
+	t.Setenv(key+"_FILE", "")
+}
+
+func writeTestSecretFile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write test secret: %v", err)
+	}
+
+	return path
+}


### PR DESCRIPTION
## Summary
- add file-backed credential lookup for Tailscale OAuth and API key variables
- support both `FILE__VARIABLE_NAME` and `VARIABLE_NAME_FILE` conventions, with direct env vars taking precedence
- wire e2e to provide DockTail OAuth credentials through mounted secret files, covering both conventions in one run
- document file-backed secrets in the admin/reference docs and README

## Validation
- Ran `gofmt -w main.go main_test.go`
- Ran `git diff --check`
- Did not run tests or start services per project instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for mounting Tailscale credentials from files using `FILE__TAILSCALE_OAUTH_CLIENT_ID`, `TAILSCALE_OAUTH_CLIENT_SECRET_FILE`, and `TAILSCALE_API_KEY_FILE` environment variables for enhanced security in containerized deployments.

* **Documentation**
  * Updated configuration examples and guides to document file-based secret mounting for Tailscale credentials.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marvinvr/docktail/pull/52)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->