### PR TITLE
Support Funnel path labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ labels:
   - "docktail.funnel.funnel-port=8443"
 ```
 
+Mount an HTTP(S) Funnel at a path:
+
+```yaml
+labels:
+  - "docktail.funnel.enable=true"
+  - "docktail.funnel.port=3000"
+  - "docktail.funnel.path=/webhook"
+```
+
 ## Documentation
 
 - Human docs: https://docktail.org/docs/

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -206,6 +206,17 @@ services:
       - "docktail.funnel.enable=true"
       - "docktail.funnel.port=80"
 
+  # Second HTTPS funnel sharing port 443 at a different path
+  test-funnel-path:
+    image: nginx:alpine
+    container_name: e2e-funnel-path
+    restart: "no"
+    labels:
+      - "docktail.funnel.enable=true"
+      - "docktail.funnel.port=80"
+      - "docktail.funnel.funnel-port=443"
+      - "docktail.funnel.path=/e2e-path"
+
   # Funnel-only container on port 8443
   test-funnel-only:
     image: nginx:alpine

--- a/docker/client.go
+++ b/docker/client.go
@@ -375,12 +375,12 @@ func (c *Client) parseFunnelConfig(cctx *containerCtx, labels map[string]string)
 	}
 
 	funnelPathLabel, hasFunnelPath := labels[apptypes.LabelFunnelPath]
+	if hasFunnelPath && (funnelProtocol == "tcp" || funnelProtocol == "tls-terminated-tcp") {
+		return nil, fmt.Errorf("%s is only supported for HTTP/HTTPS funnels", apptypes.LabelFunnelPath)
+	}
 	funnelPath, err := parseFunnelPath(funnelPathLabel)
 	if err != nil {
 		return nil, err
-	}
-	if hasFunnelPath && (funnelProtocol == "tcp" || funnelProtocol == "tls-terminated-tcp") {
-		return nil, fmt.Errorf("%s is only supported for HTTP/HTTPS funnels", apptypes.LabelFunnelPath)
 	}
 
 	funnelDestIP, funnelTargetPort, err := c.resolveDestPort(cctx, funnelPort)

--- a/docker/client.go
+++ b/docker/client.go
@@ -322,6 +322,18 @@ type funnelConfig struct {
 	TargetPort string
 	PublicPort string
 	Protocol   string
+	Path       string
+}
+
+func parseFunnelPath(rawPath string) (string, error) {
+	path := strings.TrimSpace(rawPath)
+	if path == "" {
+		return "/", nil
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "", fmt.Errorf("invalid funnel path: %s (must start with /)", rawPath)
+	}
+	return path, nil
 }
 
 func (c *Client) parseFunnelConfig(cctx *containerCtx, labels map[string]string) (*funnelConfig, error) {
@@ -362,6 +374,15 @@ func (c *Client) parseFunnelConfig(cctx *containerCtx, labels map[string]string)
 		return nil, fmt.Errorf("invalid funnel protocol: %s (must be http, https, tcp, or tls-terminated-tcp)", funnelProtocol)
 	}
 
+	funnelPathLabel, hasFunnelPath := labels[apptypes.LabelFunnelPath]
+	funnelPath, err := parseFunnelPath(funnelPathLabel)
+	if err != nil {
+		return nil, err
+	}
+	if hasFunnelPath && (funnelProtocol == "tcp" || funnelProtocol == "tls-terminated-tcp") {
+		return nil, fmt.Errorf("%s is only supported for HTTP/HTTPS funnels", apptypes.LabelFunnelPath)
+	}
+
 	funnelDestIP, funnelTargetPort, err := c.resolveDestPort(cctx, funnelPort)
 	if err != nil {
 		return nil, err
@@ -373,6 +394,7 @@ func (c *Client) parseFunnelConfig(cctx *containerCtx, labels map[string]string)
 		Str("funnel_host_port", funnelTargetPort).
 		Str("funnel_public_port", funnelFunnelPort).
 		Str("funnel_protocol", funnelProtocol).
+		Str("funnel_path", funnelPath).
 		Msg("Funnel enabled for public internet access")
 
 	return &funnelConfig{
@@ -381,6 +403,7 @@ func (c *Client) parseFunnelConfig(cctx *containerCtx, labels map[string]string)
 		TargetPort: funnelTargetPort,
 		PublicPort: funnelFunnelPort,
 		Protocol:   funnelProtocol,
+		Path:       funnelPath,
 	}, nil
 }
 
@@ -499,6 +522,7 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 		result[0].FunnelTargetPort = funnelCfg.TargetPort
 		result[0].FunnelFunnelPort = funnelCfg.PublicPort
 		result[0].FunnelProtocol = funnelCfg.Protocol
+		result[0].FunnelPath = funnelCfg.Path
 		return result, nil
 	}
 
@@ -513,6 +537,7 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 		FunnelTargetPort: funnelCfg.TargetPort,
 		FunnelFunnelPort: funnelCfg.PublicPort,
 		FunnelProtocol:   funnelCfg.Protocol,
+		FunnelPath:       funnelCfg.Path,
 	})
 
 	return result, nil

--- a/docker/client_test.go
+++ b/docker/client_test.go
@@ -238,6 +238,59 @@ func TestManagedContainerDetection(t *testing.T) {
 	}
 }
 
+func TestParseFunnelPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      string
+		wantError bool
+	}{
+		{
+			name:  "empty path defaults to root",
+			input: "",
+			want:  "/",
+		},
+		{
+			name:  "root path",
+			input: "/",
+			want:  "/",
+		},
+		{
+			name:  "nested path",
+			input: "/webhook/github",
+			want:  "/webhook/github",
+		},
+		{
+			name:  "trims whitespace",
+			input: " /foobar ",
+			want:  "/foobar",
+		},
+		{
+			name:      "missing leading slash",
+			input:     "foobar",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFunnelPath(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseFunnelPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIndexedPortRegex(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/docs/04-labels.md
+++ b/docs/04-labels.md
@@ -66,10 +66,13 @@ Funnel exposes a service to the public internet. It can be used together with a 
 | `docktail.funnel.port` | Yes | - | Backend container port for Funnel traffic. |
 | `docktail.funnel.funnel-port` | No | `443` | Public Funnel port. HTTPS/HTTP Funnel supports `443`, `8443`, or `10000`. |
 | `docktail.funnel.protocol` | No | `https` | Funnel protocol: `http`, `https`, `tcp`, or `tls-terminated-tcp`. |
+| `docktail.funnel.path` | No | `/` | HTTP(S) Funnel path. Must start with `/`. |
 
 Funnel notes:
 
-- Tailscale supports only one active Funnel per public port on a node.
+- HTTP(S) Funnels can share a public port when each Funnel uses a different `docktail.funnel.path`.
+- TCP and TLS-terminated TCP Funnels support only one active Funnel per public port on a node.
+- `docktail.funnel.path` is only valid for HTTP(S) Funnels.
 - Funnel URLs use the machine hostname, not the Tailscale service name.
 - Funnel-only containers can omit `docktail.service.enable` and other `docktail.service.*` labels.
 - `docktail.service.direct` and `docktail.service.network` still control how DockTail reaches the backend for Funnel traffic.

--- a/docs/05-examples.md
+++ b/docs/05-examples.md
@@ -132,3 +132,18 @@ services:
 ```
 
 Access it publicly at `https://your-machine.your-tailnet.ts.net:8443`.
+
+### Public Funnel Mounted At A Path
+
+```yaml
+services:
+  webhook:
+    image: my-webhook:latest
+    labels:
+      - "docktail.funnel.enable=true"
+      - "docktail.funnel.port=3000"
+      - "docktail.funnel.funnel-port=443"
+      - "docktail.funnel.path=/webhook"
+```
+
+Access it publicly at `https://your-machine.your-tailnet.ts.net/webhook`.

--- a/docs/06-reference.md
+++ b/docs/06-reference.md
@@ -61,6 +61,8 @@ Funnel `docktail.funnel.protocol` values:
 | `tcp` | TCP Funnel. |
 | `tls-terminated-tcp` | TLS-terminated TCP Funnel. |
 
+`docktail.funnel.path` is supported only with HTTP(S) Funnel protocols. It defaults to `/` and must start with `/`.
+
 ### Cleanup Behavior
 
 DockTail cleans up the services it advertises locally when it shuts down. It does not delete Tailscale service definitions from the Admin Console API when containers stop; this is a conservative deletion strategy to avoid removing definitions unexpectedly.

--- a/e2e.sh
+++ b/e2e.sh
@@ -242,7 +242,7 @@ assert_funnel_path() {
     local path="$2"
     local funnel_status
     funnel_status=$(get_funnel_status)
-    if echo "$funnel_status" | jq -e --arg port "$port" --arg path "$path" '.Web | to_entries[] | select(.key | endswith(":" + $port)) | .value.Handlers[$path].Proxy? // empty' >/dev/null 2>&1; then
+    if echo "$funnel_status" | jq -e --arg port "$port" --arg path "$path" '.Web | to_entries[] | select(.key | endswith(":" + $port)) | .value.Handlers[$path].Proxy? | strings | select(length > 0)' >/dev/null 2>&1; then
         pass "funnel path $path active on port $port"
     else
         fail "funnel path $path not found on port $port"

--- a/e2e.sh
+++ b/e2e.sh
@@ -237,6 +237,18 @@ assert_funnel_active() {
     fi
 }
 
+assert_funnel_path() {
+    local port="$1"
+    local path="$2"
+    local funnel_status
+    funnel_status=$(get_funnel_status)
+    if echo "$funnel_status" | jq -e --arg port "$port" --arg path "$path" '.Web | to_entries[] | select(.key | endswith(":" + $port)) | .value.Handlers[$path].Proxy? // empty' >/dev/null 2>&1; then
+        pass "funnel path $path active on port $port"
+    else
+        fail "funnel path $path not found on port $port"
+    fi
+}
+
 wait_for_docktail_log() {
     local pattern="$1"
     local timeout="${2:-$RECONCILE_WAIT}"
@@ -377,6 +389,8 @@ log "4. Funnel"
 echo "  --- service + funnel ---"
 assert_service_exists       "e2e-funnel"
 assert_funnel_active        "443"
+assert_funnel_path          "443" "/"
+assert_funnel_path          "443" "/e2e-path"
 
 echo "  --- funnel only ---"
 assert_service_not_exists   "e2e-funnel-only"

--- a/tailscale/funnel.go
+++ b/tailscale/funnel.go
@@ -30,6 +30,7 @@ type FunnelHandler struct {
 
 type CurrentFunnel struct {
 	PublicPort  string
+	Path        string
 	Protocol    string
 	Destination string
 }
@@ -62,20 +63,40 @@ func detectFunnelProtocol(config map[string]bool) string {
 	return ""
 }
 
-func firstProxy(config FunnelWebConfig) string {
-	for _, handler := range config.Handlers {
-		if handler.Proxy != "" {
-			return handler.Proxy
-		}
-	}
-	return ""
-}
-
 func normalizeDesiredFunnelProtocol(protocol string) string {
 	if protocol == "http" {
 		return "https"
 	}
 	return protocol
+}
+
+func normalizeFunnelPath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+func isHTTPFunnelProtocol(protocol string) bool {
+	return normalizeDesiredFunnelProtocol(protocol) == "https"
+}
+
+func funnelKey(publicPort, path, protocol string) string {
+	if isHTTPFunnelProtocol(protocol) {
+		return publicPort + "|" + normalizeFunnelPath(path)
+	}
+	return publicPort
+}
+
+func desiredFunnelKey(svc *apptypes.ContainerService) string {
+	return funnelKey(svc.FunnelFunnelPort, svc.FunnelPath, svc.FunnelProtocol)
+}
+
+func desiredFunnelEndpoint(svc *apptypes.ContainerService) string {
+	if isHTTPFunnelProtocol(svc.FunnelProtocol) {
+		return svc.FunnelFunnelPort + normalizeFunnelPath(svc.FunnelPath)
+	}
+	return svc.FunnelFunnelPort
 }
 
 func desiredFunnelDestination(svc *apptypes.ContainerService) string {
@@ -100,6 +121,10 @@ func currentFunnelMatchesDesired(current CurrentFunnel, svc *apptypes.ContainerS
 		return false
 	}
 
+	if isHTTPFunnelProtocol(svc.FunnelProtocol) && normalizeFunnelPath(current.Path) != normalizeFunnelPath(svc.FunnelPath) {
+		return false
+	}
+
 	if current.Destination != "" && current.Destination != desiredFunnelDestination(svc) {
 		return false
 	}
@@ -120,8 +145,77 @@ func managedFunnelPortSet(ports map[string]struct{}) map[string]struct{} {
 	return cloned
 }
 
+func parseFunnelStatus(status FunnelStatus) map[string]CurrentFunnel {
+	funnels := make(map[string]CurrentFunnel)
+	for hostPort := range status.AllowFunnel {
+		port := extractPort(hostPort)
+		if port == "" {
+			continue
+		}
+
+		current := funnels[port]
+		current.PublicPort = port
+		current.Protocol = detectFunnelProtocol(status.TCP[port])
+		funnels[port] = current
+
+		log.Debug().
+			Str("host_port", hostPort).
+			Str("port", port).
+			Msg("Detected active funnel")
+	}
+
+	for port, tcpConfig := range status.TCP {
+		protocol := detectFunnelProtocol(tcpConfig)
+		key := funnelKey(port, "", protocol)
+		current := funnels[key]
+		if existing, ok := funnels[port]; ok {
+			current = existing
+			delete(funnels, port)
+		}
+		current.PublicPort = port
+		if current.Protocol == "" {
+			current.Protocol = protocol
+		}
+		if isHTTPFunnelProtocol(current.Protocol) {
+			current.Path = normalizeFunnelPath(current.Path)
+		}
+		funnels[key] = current
+	}
+
+	for webKey, webConfig := range status.Web {
+		port := extractPort(webKey)
+		if port == "" {
+			continue
+		}
+
+		for path, handler := range webConfig.Handlers {
+			if handler.Proxy == "" {
+				continue
+			}
+
+			normalizedPath := normalizeFunnelPath(path)
+			key := funnelKey(port, normalizedPath, "https")
+			current := funnels[key]
+			if existing, ok := funnels[port]; ok {
+				current = existing
+				delete(funnels, port)
+			}
+			current.PublicPort = port
+			current.Path = normalizedPath
+			if current.Protocol == "" {
+				current.Protocol = "https"
+			}
+			current.Destination = handler.Proxy
+			funnels[key] = current
+		}
+	}
+
+	return funnels
+}
+
 // getCurrentFunnels retrieves the current funnel status
-// Returns a map keyed by public port (for example "443").
+// Returns a map keyed by public port for TCP-style funnels and public port plus
+// path for HTTP(S) funnels.
 func (c *Client) getCurrentFunnels(ctx context.Context) (map[string]CurrentFunnel, error) {
 	cmd := c.tailscaleCmd(ctx, "funnel", "status", "--json")
 	output, err := cmd.CombinedOutput()
@@ -156,47 +250,7 @@ func (c *Client) getCurrentFunnels(ctx context.Context) (map[string]CurrentFunne
 		return make(map[string]CurrentFunnel), nil
 	}
 
-	funnels := make(map[string]CurrentFunnel)
-	for hostPort := range status.AllowFunnel {
-		port := extractPort(hostPort)
-		if port == "" {
-			continue
-		}
-
-		current := funnels[port]
-		current.PublicPort = port
-		current.Protocol = detectFunnelProtocol(status.TCP[port])
-		funnels[port] = current
-
-		log.Debug().
-			Str("host_port", hostPort).
-			Str("port", port).
-			Msg("Detected active funnel")
-	}
-
-	for port, tcpConfig := range status.TCP {
-		current := funnels[port]
-		current.PublicPort = port
-		if current.Protocol == "" {
-			current.Protocol = detectFunnelProtocol(tcpConfig)
-		}
-		funnels[port] = current
-	}
-
-	for webKey, webConfig := range status.Web {
-		port := extractPort(webKey)
-		if port == "" {
-			continue
-		}
-
-		current := funnels[port]
-		current.PublicPort = port
-		if current.Protocol == "" {
-			current.Protocol = "https"
-		}
-		current.Destination = firstProxy(webConfig)
-		funnels[port] = current
-	}
+	funnels := parseFunnelStatus(status)
 
 	log.Debug().
 		Int("funnel_count", len(funnels)).
@@ -219,31 +273,33 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 		currentFunnels = make(map[string]CurrentFunnel)
 	}
 
-	// Build map of desired funnels and check for duplicate funnel-ports
-	// Tailscale limitation: only ONE funnel can be active per funnel-port
+	// Build map of desired funnels and check for duplicate funnel targets.
+	// HTTP(S) funnels can share a public port when their paths differ. TCP-style
+	// funnels are still limited to one active funnel per public port.
 	desiredFunnels := make(map[string]*apptypes.ContainerService)
 	funnelPortUsage := make(map[string]string) // funnel-port -> container name
 	var duplicatePortErrors []string
 
 	for _, svc := range desiredServices {
 		if svc.FunnelEnabled {
-			key := svc.FunnelFunnelPort
+			key := desiredFunnelKey(svc)
 			desiredFunnels[key] = svc
 
-			// Check for duplicate funnel-port usage
-			if existingContainer, exists := funnelPortUsage[svc.FunnelFunnelPort]; exists {
+			// Check for duplicate funnel destination usage.
+			if existingContainer, exists := funnelPortUsage[key]; exists {
 				errMsg := fmt.Sprintf(
-					"funnel-port %s conflict: containers '%s' and '%s' cannot share the same funnel-port (Tailscale limitation: only ONE funnel per port)",
-					svc.FunnelFunnelPort, existingContainer, svc.ContainerName,
+					"funnel target %s conflict: containers '%s' and '%s' cannot share the same public funnel endpoint",
+					key, existingContainer, svc.ContainerName,
 				)
 				duplicatePortErrors = append(duplicatePortErrors, errMsg)
 				log.Error().
 					Str("funnel_port", svc.FunnelFunnelPort).
+					Str("funnel_path", svc.FunnelPath).
 					Str("container1", existingContainer).
 					Str("container2", svc.ContainerName).
-					Msg("Duplicate funnel-port detected - only one funnel can be active per port")
+					Msg("Duplicate funnel target detected")
 			} else {
-				funnelPortUsage[svc.FunnelFunnelPort] = svc.ContainerName
+				funnelPortUsage[key] = svc.ContainerName
 			}
 		}
 	}
@@ -253,21 +309,21 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 		for _, errMsg := range duplicatePortErrors {
 			log.Error().Msg(errMsg)
 		}
-		return fmt.Errorf("funnel configuration error: %d containers have conflicting funnel-ports (only ONE funnel allowed per port)", len(duplicatePortErrors))
+		return fmt.Errorf("funnel configuration error: %d containers have conflicting funnel endpoints", len(duplicatePortErrors))
 	}
 
 	previouslyManaged := managedFunnelPortSet(c.managedFunnels)
 	staleManagedFunnels := make([]string, 0)
 	unmanagedCurrentFunnels := make([]string, 0)
 
-	for publicPort := range currentFunnels {
-		if _, managed := previouslyManaged[publicPort]; managed {
-			if _, desired := desiredFunnels[publicPort]; !desired {
-				staleManagedFunnels = append(staleManagedFunnels, publicPort)
+	for currentKey := range currentFunnels {
+		if _, managed := previouslyManaged[currentKey]; managed {
+			if _, desired := desiredFunnels[currentKey]; !desired {
+				staleManagedFunnels = append(staleManagedFunnels, currentKey)
 			}
 			continue
 		}
-		unmanagedCurrentFunnels = append(unmanagedCurrentFunnels, publicPort)
+		unmanagedCurrentFunnels = append(unmanagedCurrentFunnels, currentKey)
 	}
 
 	if len(staleManagedFunnels) > 0 {
@@ -292,21 +348,23 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 	// Find funnels to add or update.
 	var applyErrors []error
 	successfulFunnels := make(map[string]struct{}, len(desiredFunnels)+len(staleManagedFunnels))
-	for publicPort, svc := range desiredFunnels {
-		current, exists := currentFunnels[publicPort]
+	for key, svc := range desiredFunnels {
+		current, exists := currentFunnels[key]
 
 		if exists && currentFunnelMatchesDesired(current, svc) {
 			log.Debug().
 				Str("container", svc.ContainerName).
 				Str("public_port", svc.FunnelFunnelPort).
+				Str("funnel_path", svc.FunnelPath).
 				Msg("Funnel already configured correctly")
-			successfulFunnels[publicPort] = struct{}{}
+			successfulFunnels[key] = struct{}{}
 			continue
 		}
 
 		log.Info().
 			Str("container", svc.ContainerName).
 			Str("public_port", svc.FunnelFunnelPort).
+			Str("funnel_path", svc.FunnelPath).
 			Msg("Enabling funnel")
 
 		if err := c.addFunnel(ctx, svc); err != nil {
@@ -314,15 +372,15 @@ func (c *Client) reconcileFunnels(ctx context.Context, desiredServices []*apptyp
 				Err(err).
 				Str("container", svc.ContainerName).
 				Msg("Failed to enable funnel")
-			applyErrors = append(applyErrors, fmt.Errorf("%s:%s: %w", svc.ContainerName, publicPort, err))
+			applyErrors = append(applyErrors, fmt.Errorf("%s:%s: %w", svc.ContainerName, key, err))
 			continue
 		}
 
-		successfulFunnels[publicPort] = struct{}{}
+		successfulFunnels[key] = struct{}{}
 	}
 
-	for _, publicPort := range staleManagedFunnels {
-		successfulFunnels[publicPort] = struct{}{}
+	for _, key := range staleManagedFunnels {
+		successfulFunnels[key] = struct{}{}
 	}
 	c.managedFunnels = successfulFunnels
 
@@ -352,7 +410,8 @@ func (c *Client) addFunnel(ctx context.Context, svc *apptypes.ContainerService) 
 	case "https", "http":
 		// HTTPS funnel: tailscale funnel --bg --https=<funnel-port> http://localhost:<host-port>
 		portArg := fmt.Sprintf("--https=%s", svc.FunnelFunnelPort)
-		cmd = c.tailscaleCmd(ctx, "funnel", "--bg", portArg, funnelDestination)
+		pathArg := fmt.Sprintf("--set-path=%s", normalizeFunnelPath(svc.FunnelPath))
+		cmd = c.tailscaleCmd(ctx, "funnel", "--bg", portArg, pathArg, funnelDestination)
 
 	case "tcp":
 		// TCP funnel: tailscale funnel --bg --tcp=<funnel-port> tcp://localhost:<host-port>
@@ -377,6 +436,7 @@ func (c *Client) addFunnel(ctx context.Context, svc *apptypes.ContainerService) 
 		Str("funnel_container_port", svc.FunnelPort).
 		Str("funnel_host_port", svc.FunnelTargetPort).
 		Str("funnel_public_port", svc.FunnelFunnelPort).
+		Str("funnel_path", svc.FunnelPath).
 		Str("destination", funnelDestination).
 		Msg("Executing tailscale funnel command (uses machine hostname, not service name)")
 
@@ -399,7 +459,7 @@ func (c *Client) addFunnel(ctx context.Context, svc *apptypes.ContainerService) 
 		return fmt.Errorf("funnel command succeeded but status verification failed: %w", verifyErr)
 	}
 
-	current, exists := currentFunnels[svc.FunnelFunnelPort]
+	current, exists := currentFunnels[desiredFunnelKey(svc)]
 	if !exists || !currentFunnelMatchesDesired(current, svc) {
 		stderr := string(output)
 		if isFunnelACLError(stderr) {
@@ -411,14 +471,15 @@ func (c *Client) addFunnel(ctx context.Context, svc *apptypes.ContainerService) 
 			)
 		}
 		return fmt.Errorf(
-			"tailscale funnel command completed but the requested public port %s is not active.\nOutput: %s",
-			svc.FunnelFunnelPort, stderr,
+			"tailscale funnel command completed but the requested public endpoint %s is not active.\nOutput: %s",
+			desiredFunnelEndpoint(svc), stderr,
 		)
 	}
 
 	log.Info().
 		Str("container", svc.ContainerName).
 		Str("public_port", svc.FunnelFunnelPort).
+		Str("funnel_path", svc.FunnelPath).
 		Str("protocol", svc.FunnelProtocol).
 		Msg("Funnel enabled - publicly accessible at https://<machine-hostname>.<tailnet>.ts.net:" + svc.FunnelFunnelPort)
 

--- a/tailscale/funnel.go
+++ b/tailscale/funnel.go
@@ -166,6 +166,11 @@ func parseFunnelStatus(status FunnelStatus) map[string]CurrentFunnel {
 
 	for port, tcpConfig := range status.TCP {
 		protocol := detectFunnelProtocol(tcpConfig)
+		if isHTTPFunnelProtocol(protocol) {
+			delete(funnels, port)
+			continue
+		}
+
 		key := funnelKey(port, "", protocol)
 		current := funnels[key]
 		if existing, ok := funnels[port]; ok {
@@ -175,9 +180,6 @@ func parseFunnelStatus(status FunnelStatus) map[string]CurrentFunnel {
 		current.PublicPort = port
 		if current.Protocol == "" {
 			current.Protocol = protocol
-		}
-		if isHTTPFunnelProtocol(current.Protocol) {
-			current.Path = normalizeFunnelPath(current.Path)
 		}
 		funnels[key] = current
 	}

--- a/tailscale/service_test.go
+++ b/tailscale/service_test.go
@@ -242,12 +242,119 @@ func TestFunnelStatusParsing(t *testing.T) {
 	}
 }
 
+func TestParseFunnelStatus(t *testing.T) {
+	status := FunnelStatus{
+		TCP: map[string]map[string]bool{
+			"443":  {"HTTPS": true},
+			"8443": {"HTTPS": true},
+			"10000": {
+				"TCP": true,
+			},
+		},
+		Web: map[string]FunnelWebConfig{
+			"https://myhost.tail1234.ts.net:443": {
+				Handlers: map[string]FunnelHandler{
+					"/":       {Proxy: "http://172.22.0.13:3000"},
+					"/foobar": {Proxy: "http://172.22.0.14:4000"},
+				},
+			},
+			"https://myhost.tail1234.ts.net:8443": {
+				Handlers: map[string]FunnelHandler{
+					"/hooks/github": {Proxy: "http://172.22.0.15:5000"},
+				},
+			},
+		},
+		AllowFunnel: map[string]bool{
+			"myhost.tail1234.ts.net:443":   true,
+			"myhost.tail1234.ts.net:8443":  true,
+			"myhost.tail1234.ts.net:10000": true,
+		},
+	}
+
+	funnels := parseFunnelStatus(status)
+
+	tests := []struct {
+		name        string
+		key         string
+		wantPort    string
+		wantPath    string
+		wantProto   string
+		wantDest    string
+		wantPresent bool
+	}{
+		{
+			name:        "root handler",
+			key:         "443|/",
+			wantPort:    "443",
+			wantPath:    "/",
+			wantProto:   "https",
+			wantDest:    "http://172.22.0.13:3000",
+			wantPresent: true,
+		},
+		{
+			name:        "path handler sharing port",
+			key:         "443|/foobar",
+			wantPort:    "443",
+			wantPath:    "/foobar",
+			wantProto:   "https",
+			wantDest:    "http://172.22.0.14:4000",
+			wantPresent: true,
+		},
+		{
+			name:        "nested path handler",
+			key:         "8443|/hooks/github",
+			wantPort:    "8443",
+			wantPath:    "/hooks/github",
+			wantProto:   "https",
+			wantDest:    "http://172.22.0.15:5000",
+			wantPresent: true,
+		},
+		{
+			name:        "tcp funnel remains keyed by port only",
+			key:         "10000",
+			wantPort:    "10000",
+			wantProto:   "tcp",
+			wantPresent: true,
+		},
+		{
+			name:        "http path is not collapsed to port",
+			key:         "443",
+			wantPresent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := funnels[tt.key]
+			if ok != tt.wantPresent {
+				t.Fatalf("presence for key %q = %v, want %v", tt.key, ok, tt.wantPresent)
+			}
+			if !tt.wantPresent {
+				return
+			}
+			if got.PublicPort != tt.wantPort {
+				t.Errorf("PublicPort = %q, want %q", got.PublicPort, tt.wantPort)
+			}
+			if got.Path != tt.wantPath {
+				t.Errorf("Path = %q, want %q", got.Path, tt.wantPath)
+			}
+			if got.Protocol != tt.wantProto {
+				t.Errorf("Protocol = %q, want %q", got.Protocol, tt.wantProto)
+			}
+			if got.Destination != tt.wantDest {
+				t.Errorf("Destination = %q, want %q", got.Destination, tt.wantDest)
+			}
+		})
+	}
+}
+
 func TestCurrentFunnelMatchesDesired(t *testing.T) {
 	desired := &apptypes.ContainerService{
 		IPAddress:        "172.22.0.13",
 		FunnelTargetPort: "3000",
 		FunnelFunnelPort: "8443",
 		FunnelProtocol:   "https",
+		FunnelPath:       "/",
 	}
 
 	tests := []struct {
@@ -259,15 +366,27 @@ func TestCurrentFunnelMatchesDesired(t *testing.T) {
 			name: "matching https funnel",
 			current: CurrentFunnel{
 				PublicPort:  "8443",
+				Path:        "/",
 				Protocol:    "https",
 				Destination: "http://172.22.0.13:3000",
 			},
 			want: true,
 		},
 		{
+			name: "mismatched path",
+			current: CurrentFunnel{
+				PublicPort:  "8443",
+				Path:        "/foo",
+				Protocol:    "https",
+				Destination: "http://172.22.0.13:3000",
+			},
+			want: false,
+		},
+		{
 			name: "mismatched destination",
 			current: CurrentFunnel{
 				PublicPort:  "8443",
+				Path:        "/",
 				Protocol:    "https",
 				Destination: "http://172.22.0.13:8080",
 			},

--- a/tailscale/service_test.go
+++ b/tailscale/service_test.go
@@ -321,6 +321,11 @@ func TestParseFunnelStatus(t *testing.T) {
 			key:         "443",
 			wantPresent: false,
 		},
+		{
+			name:        "no phantom root entry when only non-root handler exists",
+			key:         "8443|/",
+			wantPresent: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/types/types.go
+++ b/types/types.go
@@ -17,6 +17,7 @@ type ContainerService struct {
 	FunnelTargetPort string // Host port that maps to FunnelPort
 	FunnelFunnelPort string // Public-facing port (443, 8443, or 10000 for HTTPS)
 	FunnelProtocol   string // Funnel protocol (https, tcp, tls-terminated-tcp)
+	FunnelPath       string // HTTP(S) Funnel path (for example "/" or "/webhook")
 }
 
 // TailscaleServiceConfig represents the JSON structure for Tailscale service configuration
@@ -43,6 +44,7 @@ const (
 	LabelFunnelPort       = "docktail.funnel.port"        // Container port (like service.port)
 	LabelFunnelFunnelPort = "docktail.funnel.funnel-port" // Public port (443, 8443, 10000)
 	LabelFunnelProtocol   = "docktail.funnel.protocol"
+	LabelFunnelPath       = "docktail.funnel.path"
 	LabelDirect           = "docktail.service.direct"  // Direct container IP proxying (default: true, set to "false" to use published ports)
 	LabelNetwork          = "docktail.service.network" // Docker network to use for container IP (default: bridge or first available)
 )


### PR DESCRIPTION
## Summary
- Add `docktail.funnel.path` for HTTP(S) Funnel mount paths, defaulting to `/`
- Track current Funnel state by public port and path so multiple HTTP(S) handlers can share one port
- Reject path labels for TCP-style funnels and document the new behavior

Closes #47

## Testing
- Not run per repository instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP(S) Funnels now support URL path routing, letting multiple funnels share a public port when using different paths.

* **Documentation**
  * Added examples and reference docs showing how to configure funnel paths and constraints.

* **Tests / E2E**
  * New unit and end-to-end checks validate funnel path parsing and runtime path routing behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marvinvr/docktail/pull/53)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->