### PR TITLE
docs: clarify SSH example to use `-l` username form

### DIFF
--- a/docs/05-examples.md
+++ b/docs/05-examples.md
@@ -51,7 +51,7 @@ services:
 
 Access 
 - https at `https://forgejo.your-tailnet.ts.net` 
-- ssh at `ssh -T git@forgejo.your-tailnet.ts.net`
+- ssh at `ssh -T -l git forgejo.your-tailnet.ts.net`
 
 ### Database Over TCP
 


### PR DESCRIPTION
### Motivation
- Clarify the SSH example in the examples documentation by using the explicit `-l` flag for specifying the username to avoid ambiguity across clients.

### Description
- Updated `docs/05-examples.md` to replace the SSH access line from `ssh -T git@forgejo.your-tailnet.ts.net` to `ssh -T -l git forgejo.your-tailnet.ts.net`.

### Testing
- No automated tests were required or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06bfed8f908330a442bf48650dd22a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SSH access instructions for Forgejo service with corrected command syntax.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marvinvr/docktail/pull/55)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->