### PR TITLE
Fix #56: TCP services re-added on every reconciliation

### DIFF
--- a/e2e.sh
+++ b/e2e.sh
@@ -538,10 +538,53 @@ assert_service_not_exists   "e2e-ignored"    # still ignored
 assert_service_not_exists   "e2e-manual-protected"  # cleaned up explicitly
 
 # ==============================================================================
-# 12. Log Health
+# 12. TCP Reconciliation Stability (issue #56)
+# ==============================================================================
+#
+# Regression test for https://github.com/marvinvr/docktail/issues/56:
+# TCP services were detected as "changed" on every reconciliation cycle because
+# the current destination could not be parsed from the Tailscale serve status
+# (the TCP forward target lives on the TCP handler, not in the Web section).
+# This caused DockTail to re-add the TCP service on every reconciliation cycle,
+# even though the live configuration already matched the desired state.
+#
+# A correctly reconciling TCP service is flagged as "changed" zero times once it
+# has been established. We measure the number of "Service configuration changed"
+# log lines for the TCP service over several reconciliation cycles; with the bug
+# present the count grows by one per cycle, with the fix it stays flat.
+
+log "12. TCP Reconciliation Stability (issue #56)"
+
+tcp_changed_key="key=svc:e2e-proto-tcp:5432"
+
+count_tcp_changed() {
+    docker logs "$DOCKTAIL_CONTAINER" 2>&1 \
+        | grep "Service configuration changed, will update" \
+        | grep -c -- "$tcp_changed_key" || true
+}
+
+echo "  --- Pre-check: TCP service exists ---"
+refresh_serve_status
+assert_service_exists       "e2e-proto-tcp"
+assert_service_protocol     "e2e-proto-tcp" "tcp"
+
+echo "  Measuring TCP reconciliation stability across multiple cycles..."
+before_changed=$(count_tcp_changed)
+sleep 16   # >= 3 reconcile cycles at RECONCILE_INTERVAL=5s
+after_changed=$(count_tcp_changed)
+changed_delta=$((after_changed - before_changed))
+
+if [ "$changed_delta" -le 0 ]; then
+    pass "TCP service stable: not re-detected as changed across cycles (delta=$changed_delta)"
+else
+    fail "TCP service re-detected as changed $changed_delta time(s) across reconcile cycles (issue #56: TCP services re-added every reconciliation)"
+fi
+
+# ==============================================================================
+# 13. Log Health
 # ==============================================================================
 
-log "12. DockTail Log Health"
+log "13. DockTail Log Health"
 docktail_logs=$(docker logs "$DOCKTAIL_CONTAINER" 2>&1)
 
 if grep -qE "FATAL|panic" <<<"$docktail_logs"; then

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -120,6 +120,10 @@ type TailscaleService struct {
 type TailscaleTCPConfig struct {
 	HTTP  bool `json:"HTTP"`
 	HTTPS bool `json:"HTTPS"`
+	// TCPForward is the backend address ("host:port") for plain-TCP service
+	// endpoints. HTTP/HTTPS endpoints leave this empty and store their backend
+	// in the Web handler config instead.
+	TCPForward string `json:"TCPForward"`
 }
 
 type TailscaleWebConfig struct {
@@ -183,7 +187,7 @@ func (c *Client) ReconcileServices(ctx context.Context, desiredServices []*appty
 		} else {
 			// Service exists - check if configuration changed
 			expectedDest := buildDestination(desired)
-			if current.Destination != expectedDest || current.Protocol != desired.ServiceProtocol {
+			if !sameDestination(current.Destination, expectedDest) || current.Protocol != desired.ServiceProtocol {
 				toAdd[key] = desired
 				log.Info().
 					Str("key", key).

--- a/tailscale/service.go
+++ b/tailscale/service.go
@@ -43,40 +43,32 @@ func (c *Client) GetCurrentServices(ctx context.Context) (map[string]ServiceEndp
 		Int("total_services_in_status", len(status.Services)).
 		Msg("Parsed Tailscale status JSON")
 
+	services := parseManagedServices(status)
+
+	log.Info().
+		Int("service_count", len(services)).
+		Msg("Retrieved current Tailscale services")
+
+	return services, nil
+}
+
+// parseManagedServices extracts the DockTail-managed service endpoints from a
+// parsed Tailscale serve status. It is kept separate from the CLI invocation so
+// the parsing logic (in particular how destinations are resolved per protocol)
+// can be unit tested directly.
+func parseManagedServices(status TailscaleStatus) map[string]ServiceEndpoint {
 	services := make(map[string]ServiceEndpoint)
 
-	// Parse each service
 	for serviceName, svcConfig := range status.Services {
 		// Only process services we manage (with svc: prefix)
 		if !isManagedService(serviceName) {
 			continue
 		}
 
-		// Parse TCP config to get port and protocol
+		// Parse TCP config to get port, protocol and destination
 		for port, tcpConfig := range svcConfig.TCP {
-			var protocol string
-			if tcpConfig.HTTPS {
-				protocol = "https"
-			} else if tcpConfig.HTTP {
-				protocol = "http"
-			} else {
-				protocol = "tcp"
-			}
-
-			// Get destination from Web config
-			var destination string
-			for webKey, webConfig := range svcConfig.Web {
-				// Find the matching port in the web key
-				if strings.Contains(webKey, ":"+port) {
-					for _, handler := range webConfig.Handlers {
-						if handler.Proxy != "" {
-							destination = handler.Proxy
-							break
-						}
-					}
-					break
-				}
-			}
+			protocol := serviceProtocol(tcpConfig)
+			destination := serviceDestination(svcConfig, port, tcpConfig)
 
 			// Create a unique key for this service+port combination
 			key := fmt.Sprintf("%s:%s", serviceName, port)
@@ -97,11 +89,45 @@ func (c *Client) GetCurrentServices(ctx context.Context) (map[string]ServiceEndp
 		}
 	}
 
-	log.Info().
-		Int("service_count", len(services)).
-		Msg("Retrieved current Tailscale services")
+	return services
+}
 
-	return services, nil
+// serviceProtocol maps a TCP handler's flags to the DockTail protocol name.
+func serviceProtocol(tcpConfig TailscaleTCPConfig) string {
+	switch {
+	case tcpConfig.HTTPS:
+		return "https"
+	case tcpConfig.HTTP:
+		return "http"
+	default:
+		return "tcp"
+	}
+}
+
+// serviceDestination resolves the backend destination for a service endpoint.
+// HTTP/HTTPS endpoints proxy through the Web handler config, whereas plain-TCP
+// endpoints forward directly via the TCP handler's TCPForward field. Previously
+// the destination was only read from the Web section, which is empty for plain
+// TCP services; that left their destination empty and made reconciliation treat
+// every TCP service as changed, re-adding it on each cycle (issue #56).
+func serviceDestination(svcConfig TailscaleService, port string, tcpConfig TailscaleTCPConfig) string {
+	if !tcpConfig.HTTP && !tcpConfig.HTTPS {
+		return tcpConfig.TCPForward
+	}
+
+	for webKey, webConfig := range svcConfig.Web {
+		// Find the matching port in the web key
+		if strings.Contains(webKey, ":"+port) {
+			for _, handler := range webConfig.Handlers {
+				if handler.Proxy != "" {
+					return handler.Proxy
+				}
+			}
+			break
+		}
+	}
+
+	return ""
 }
 
 // addService adds a single service using Tailscale CLI

--- a/tailscale/service_test.go
+++ b/tailscale/service_test.go
@@ -102,7 +102,7 @@ func TestTailscaleStatusParsing(t *testing.T) {
 				"Services": {
 					"svc:db": {
 						"TCP": {
-							"5432": {}
+							"5432": {"TCPForward": "172.17.0.5:5432"}
 						},
 						"Web": {}
 					}
@@ -114,6 +114,9 @@ func TestTailscaleStatusParsing(t *testing.T) {
 				tcpCfg := svc.TCP["5432"]
 				if tcpCfg.HTTP || tcpCfg.HTTPS {
 					t.Error("expected both HTTP and HTTPS to be false for TCP service")
+				}
+				if tcpCfg.TCPForward != "172.17.0.5:5432" {
+					t.Errorf("expected TCPForward 172.17.0.5:5432, got %q", tcpCfg.TCPForward)
 				}
 			},
 		},
@@ -155,6 +158,116 @@ func TestTailscaleStatusParsing(t *testing.T) {
 			}
 			if tt.checkFunc != nil {
 				tt.checkFunc(t, status)
+			}
+		})
+	}
+}
+
+func TestParseManagedServicesDestinations(t *testing.T) {
+	status := TailscaleStatus{
+		Services: map[string]TailscaleService{
+			"svc:web": {
+				TCP: map[string]TailscaleTCPConfig{
+					"443": {HTTPS: true},
+				},
+				Web: map[string]TailscaleWebConfig{
+					"https://svc:web:443": {
+						Handlers: map[string]TailscaleHandler{
+							"/": {Proxy: "http://172.17.0.2:8080"},
+						},
+					},
+				},
+			},
+			"svc:db": {
+				// Plain TCP service: destination lives on the TCP handler as
+				// TCPForward, and the Web section is empty (issue #56).
+				TCP: map[string]TailscaleTCPConfig{
+					"5432": {TCPForward: "172.17.0.3:5432"},
+				},
+				Web: map[string]TailscaleWebConfig{},
+			},
+			"manual-service": {
+				// Not managed by DockTail (no svc: prefix) -> ignored.
+				TCP: map[string]TailscaleTCPConfig{
+					"8080": {HTTP: true},
+				},
+			},
+		},
+	}
+
+	got := parseManagedServices(status)
+
+	if _, ok := got["manual-service:8080"]; ok {
+		t.Error("expected unmanaged service to be excluded")
+	}
+
+	web, ok := got["svc:web:443"]
+	if !ok {
+		t.Fatal("expected svc:web:443 endpoint")
+	}
+	if web.Protocol != "https" {
+		t.Errorf("svc:web protocol = %q, want https", web.Protocol)
+	}
+	if web.Destination != "http://172.17.0.2:8080" {
+		t.Errorf("svc:web destination = %q, want http://172.17.0.2:8080", web.Destination)
+	}
+
+	db, ok := got["svc:db:5432"]
+	if !ok {
+		t.Fatal("expected svc:db:5432 endpoint")
+	}
+	if db.Protocol != "tcp" {
+		t.Errorf("svc:db protocol = %q, want tcp", db.Protocol)
+	}
+	// The regression: TCP destination must be parsed from TCPForward, not left empty.
+	if db.Destination != "172.17.0.3:5432" {
+		t.Errorf("svc:db destination = %q, want 172.17.0.3:5432 (issue #56)", db.Destination)
+	}
+}
+
+func TestSameDestination(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		expected string
+		want     bool
+	}{
+		{
+			name:     "tcp forward without scheme matches expected tcp url",
+			current:  "172.17.0.3:5432",
+			expected: "tcp://172.17.0.3:5432",
+			want:     true,
+		},
+		{
+			name:     "http destinations with matching scheme",
+			current:  "http://172.17.0.2:8080",
+			expected: "http://172.17.0.2:8080",
+			want:     true,
+		},
+		{
+			name:     "backend scheme change is detected",
+			current:  "http://172.17.0.2:8080",
+			expected: "https://172.17.0.2:8080",
+			want:     false,
+		},
+		{
+			name:     "different host:port never matches",
+			current:  "172.17.0.3:5432",
+			expected: "tcp://172.17.0.9:5432",
+			want:     false,
+		},
+		{
+			name:     "empty current forces reapply",
+			current:  "",
+			expected: "tcp://172.17.0.3:5432",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameDestination(tt.current, tt.expected); got != tt.want {
+				t.Errorf("sameDestination(%q, %q) = %v, want %v", tt.current, tt.expected, got, tt.want)
 			}
 		})
 	}

--- a/tailscale/utils.go
+++ b/tailscale/utils.go
@@ -120,6 +120,33 @@ func (c *Client) shouldIgnoreService(serviceName string) bool {
 	return ok
 }
 
+// sameDestination reports whether two service destinations point to the same
+// backend. Tailscale records plain-TCP forwards as "host:port" (without a
+// scheme) in `serve status`, whereas HTTP/HTTPS handlers and buildDestination
+// include a "proto://" prefix. The service protocol is compared separately
+// during reconciliation, so the scheme is only compared when present on both
+// sides; the host:port must always match.
+func sameDestination(current, expected string) bool {
+	curScheme, curHostPort := splitScheme(current)
+	expScheme, expHostPort := splitScheme(expected)
+	if curHostPort != expHostPort {
+		return false
+	}
+	if curScheme != "" && expScheme != "" {
+		return curScheme == expScheme
+	}
+	return true
+}
+
+// splitScheme separates an optional "scheme://" prefix from a destination,
+// returning the scheme (without "://") and the remaining "host:port".
+func splitScheme(dest string) (scheme, hostPort string) {
+	if i := strings.Index(dest, "://"); i >= 0 {
+		return dest[:i], dest[i+3:]
+	}
+	return "", dest
+}
+
 // buildDestination constructs the destination URL for a service
 func buildDestination(svc *apptypes.ContainerService) string {
 	// Use the service protocol directly in the destination URL


### PR DESCRIPTION
## Problem

Closes #56.

Plain-TCP Tailscale services were detected as **changed on every reconciliation cycle** and re-added each pass, even when the live `tailscale serve` config already matched the desired state. The reconciler logged:

```
Service configuration changed, will update current_dest= current_protocol=tcp expected_dest=tcp://172.18.0.2:443 ...
```

i.e. `current_dest` was always empty for TCP services.

## Root cause

`GetCurrentServices` resolved the current destination **only** from the `Web` handler config (`Services[...].Web[...].Handlers[...].Proxy`). For plain-TCP endpoints the `Web` section is empty — the forward target lives on the TCP handler as `TCPForward` (`host:port`), which the parser never read. The struct `TailscaleTCPConfig` didn't even have that field. As a result `current.Destination` was always `""` for TCP services, so the `current.Destination != expectedDest` check in `ReconcileServices` was always true.

## Fix

- Add `TCPForward` to `TailscaleTCPConfig` and read it for plain-TCP endpoints (HTTP/HTTPS continue to use the `Web` proxy, unchanged).
- Compare destinations with a scheme-tolerant `sameDestination` helper: Tailscale reports TCP forwards as bare `host:port`, while `buildDestination` produces `tcp://host:port`. Host:port must always match; the scheme is only compared when present on both sides, so genuine backend-protocol changes (e.g. http→https) are still detected.
- Refactor status parsing into pure, unit-testable helpers (`parseManagedServices`, `serviceProtocol`, `serviceDestination`).

## Tests

- **E2E regression** (`e2e.sh` §12): measures how often the TCP service `e2e-proto-tcp` is flagged "changed" over several reconcile cycles; must be flat once established. On `main` this failed with *"TCP service re-detected as changed 3 time(s) across reconcile cycles"*; with the fix it stays at 0.
- **Unit tests**: `TestParseManagedServicesDestinations` (TCP destination parsed from `TCPForward`; HTTP/HTTPS unchanged; unmanaged services excluded) and `TestSameDestination`.

## Verification

The e2e test was pushed first and confirmed to fail **only** on the issue #56 assertion (81 other assertions passed) before the fix was applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed TCP service reconciliation stability by preventing unnecessary reconfiguration cycles
  * Enhanced service configuration comparison logic for more accurate change detection

* **Tests**
  * Added regression tests for TCP service stability and service destination parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->