### PR TITLE
feat: optionally delete unused Tailscale service definitions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,8 @@ TAILSCALE_TAILNET=example.com
 
 # Default tags to apply if not specified on the container
 DEFAULT_SERVICE_TAGS=tag:container
+
+# Delete tailnet Service definitions that no host advertises anymore (Optional)
+# Disabled by default. Requires API credentials. Safe to run alongside other
+# DockTail instances: a Service advertised by any host is never deleted.
+# DELETE_UNUSED_SERVICES=false

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ DockTail uses native Tailscale Services, not per-container Tailscale devices.
 - Tailscale Funnel for public internet access.
 - Multiple Tailscale services from one container.
 - Automatic reconciliation when containers restart or IPs change.
+- Optional cleanup of unused Tailscale service definitions (opt-in, safe with multiple instances).
 - Stateless Docker container runtime.
 
 ## Quick Start

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -44,6 +44,7 @@ services:
       - RECONCILE_INTERVAL=5s
       - DEFAULT_SERVICE_TAGS=tag:ci-test-container
       - IGNORE_SERVICE_NAMES=e2e-manual-protected
+      - DELETE_UNUSED_SERVICES=true
       - FILE__TAILSCALE_OAUTH_CLIENT_ID=/run/secrets/docktail/tailscale_oauth_client_id
       - TAILSCALE_OAUTH_CLIENT_SECRET_FILE=/run/secrets/docktail/tailscale_oauth_client_secret
       - TAILSCALE_TAILNET=${TS_TAILNET:-}

--- a/docs/03-tailscale-admin.md
+++ b/docs/03-tailscale-admin.md
@@ -12,6 +12,8 @@ OAuth is recommended. It enables automatic service creation and avoids expiring 
    - General -> Services: Write
    - Devices -> Core: Write
    - Keys -> Auth Keys: Write, only when using the sidecar method
+
+   These same permissions also cover the optional `DELETE_UNUSED_SERVICES` cleanup, which lists Services, inspects their advertising hosts, and deletes the ones no host advertises. No extra scope is required.
 4. Add the credentials to DockTail:
 
 ```yaml

--- a/docs/06-reference.md
+++ b/docs/06-reference.md
@@ -11,7 +11,8 @@ Use this section when checking exact configuration names, defaults, and supporte
 | `TAILSCALE_API_KEY` | - | API key alternative to OAuth. |
 | `TAILSCALE_TAILNET` | `-` | Tailnet ID. Defaults to the credential's tailnet. |
 | `DEFAULT_SERVICE_TAGS` | `tag:container` | Default tags assigned to services. |
-| `IGNORE_SERVICE_NAMES` | - | Comma-separated service names DockTail must not drain or clear during reconciliation or shutdown cleanup. |
+| `IGNORE_SERVICE_NAMES` | - | Comma-separated service names DockTail must not drain, clear, or delete during reconciliation or shutdown cleanup. |
+| `DELETE_UNUSED_SERVICES` | `false` | When `true`, DockTail deletes tailnet Service definitions that no host advertises anymore. Requires API credentials. See [Cleanup Behavior](#cleanup-behavior). |
 | `LOG_LEVEL` | `info` | Logging level: `debug`, `info`, `warn`, or `error`. |
 | `RECONCILE_INTERVAL` | `60s` | State reconciliation interval. |
 | `DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon socket. |
@@ -65,7 +66,26 @@ Funnel `docktail.funnel.protocol` values:
 
 ### Cleanup Behavior
 
-DockTail cleans up the services it advertises locally when it shuts down. It does not delete Tailscale service definitions from the Admin Console API when containers stop; this is a conservative deletion strategy to avoid removing definitions unexpectedly.
+DockTail cleans up the services it advertises locally when it shuts down.
+
+By default it does **not** delete Tailscale Service definitions from the Control Plane when containers stop; this is a conservative strategy that avoids removing definitions unexpectedly.
+
+#### Deleting unused Service definitions
+
+Set `DELETE_UNUSED_SERVICES=true` to let DockTail remove Service definitions that are no longer advertised by any host. This requires API credentials (OAuth or API key). It is disabled by default.
+
+During each reconciliation, for every Service definition in the tailnet DockTail:
+
+1. Keeps the Service if DockTail currently advertises it (it is backed by a running container).
+2. Keeps the Service if its name is listed in `IGNORE_SERVICE_NAMES`.
+3. Asks the Control Plane which hosts advertise the Service. If **at least one** host advertises it, DockTail keeps it.
+4. Deletes the Service only when **no** host advertises it.
+
+Because the decision is based on the tailnet-wide advertiser count, this is safe to enable on multiple DockTail instances at once: a Service advertised by any other host or instance always reports at least one host and is never deleted. DockTail also skips deletion whenever an API call fails, so it never deletes under uncertainty.
+
+This cleanup runs only during reconciliation, not during shutdown, so restarting DockTail does not delete and recreate the Services of still-running containers.
+
+> **Note:** When enabled, DockTail may also delete Service definitions it did not create if they have no advertising hosts (for example, a Service you defined in the admin console but never advertised). Add such names to `IGNORE_SERVICE_NAMES` to protect them.
 
 ### Useful Links
 

--- a/docs/07-how-it-works.md
+++ b/docs/07-how-it-works.md
@@ -29,7 +29,8 @@ Tailnet clients access container services
 4. It generates Tailscale service configuration pointing to that backend.
 5. It executes the Tailscale CLI to advertise services and Funnels.
 6. If OAuth or API key credentials are configured, it creates service definitions through the Tailscale API.
-7. It periodically reconciles state so container IP changes are handled automatically.
+7. If `DELETE_UNUSED_SERVICES` is enabled, it deletes tailnet service definitions that no host advertises anymore.
+8. It periodically reconciles state so container IP changes are handled automatically.
 
 ### Networking Model
 

--- a/e2e.sh
+++ b/e2e.sh
@@ -9,6 +9,12 @@ RECONCILE_WAIT=10
 SCRIPT_TIMEOUT=600
 MANUAL_PROTECTED_SERVICE_NAME="svc:e2e-manual-protected"
 MANUAL_PROTECTED_SERVICE_PORT="80"
+# Control-plane cleanup test fixtures (created directly via the Tailscale API)
+ORPHAN_SERVICE_NAME="svc:e2e-orphan"           # never advertised -> DockTail should delete it
+OTHERHOST_SERVICE_NAME="svc:e2e-otherhost"     # advertised by the node -> DockTail must keep it
+OTHERHOST_SERVICE_PORT="80"
+API_TAILNET="${TS_TAILNET:--}"
+API_BASE="https://api.tailscale.com/api/v2"
 
 # Kill the script if it runs longer than SCRIPT_TIMEOUT seconds
 ( sleep "$SCRIPT_TIMEOUT" && echo "ERROR: E2E script timed out after ${SCRIPT_TIMEOUT}s" && kill $$ ) 2>/dev/null &
@@ -28,6 +34,7 @@ cleanup() {
     log "Cleaning up"
     kill "$TIMEOUT_PID" 2>/dev/null || true
     docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+    sweep_e2e_services
     rm -rf "$E2E_SECRETS_DIR"
 }
 trap cleanup EXIT
@@ -266,6 +273,103 @@ wait_for_docktail_log() {
     done
 
     fail "docktail log missing '$pattern'"
+    return 1
+}
+
+# --- Tailscale Control Plane API helpers (for unused-service cleanup tests) ---
+
+# Mint a fresh OAuth access token. Echoes the token, or empty if no creds.
+mint_api_token() {
+    if [ -z "${TS_OAUTH_CLIENT_ID:-}" ] || [ -z "${TS_OAUTH_CLIENT_SECRET:-}" ]; then
+        echo ""
+        return
+    fi
+    curl -s -X POST "${API_BASE}/oauth/token" \
+        -u "${TS_OAUTH_CLIENT_ID}:${TS_OAUTH_CLIENT_SECRET}" \
+        -d "grant_type=client_credentials" 2>/dev/null \
+        | jq -r '.access_token // empty' 2>/dev/null || echo ""
+}
+
+# Print the HTTP status code of GET on a service definition (200 exists, 404 gone).
+api_service_status() {
+    local token="$1" name="$2"
+    curl -s -o /dev/null -w "%{http_code}" \
+        -H "Authorization: Bearer ${token}" \
+        "${API_BASE}/tailnet/${API_TAILNET}/services/${name}" 2>/dev/null || echo "000"
+}
+
+# Create/update a service definition via PUT. Echoes HTTP status code.
+api_create_service() {
+    local token="$1" name="$2"
+    curl -s -o /dev/null -w "%{http_code}" -X PUT \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/json" \
+        -d "{\"name\":\"${name}\",\"tags\":[\"tag:ci-test-container\"],\"ports\":[\"tcp:${OTHERHOST_SERVICE_PORT}\"]}" \
+        "${API_BASE}/tailnet/${API_TAILNET}/services/${name}" 2>/dev/null || echo "000"
+}
+
+# Count hosts currently advertising a service (0 = unused).
+api_service_host_count() {
+    local token="$1" name="$2"
+    curl -s -H "Authorization: Bearer ${token}" \
+        "${API_BASE}/tailnet/${API_TAILNET}/services/${name}/devices" 2>/dev/null \
+        | jq -r '.hosts | length' 2>/dev/null || echo "0"
+}
+
+# Delete a service definition (best effort).
+api_delete_service() {
+    local token="$1" name="$2"
+    curl -s -o /dev/null -X DELETE \
+        -H "Authorization: Bearer ${token}" \
+        "${API_BASE}/tailnet/${API_TAILNET}/services/${name}" 2>/dev/null || true
+}
+
+# Best-effort removal of any leftover e2e-* service definitions so repeated CI
+# runs against the shared tailnet don't accumulate orphaned services.
+sweep_e2e_services() {
+    local token leftovers name
+    token=$(mint_api_token)
+    [ -z "$token" ] && return 0
+    leftovers=$(curl -s -H "Authorization: Bearer ${token}" \
+        "${API_BASE}/tailnet/${API_TAILNET}/services" 2>/dev/null \
+        | jq -r '.vipServices[]?.name // empty' 2>/dev/null | grep '^svc:e2e-' || true)
+    for name in $leftovers; do
+        api_delete_service "$token" "$name"
+        echo "  Swept leftover service $name"
+    done
+}
+
+# Advertise / stop advertising OTHERHOST service on the node via the CLI.
+advertise_otherhost_service() {
+    docker exec "$TS_CONTAINER" tailscale serve \
+        --service="$OTHERHOST_SERVICE_NAME" \
+        --http="$OTHERHOST_SERVICE_PORT" \
+        http://127.0.0.1:19080 >/dev/null 2>&1
+}
+clear_otherhost_service() {
+    docker exec "$TS_CONTAINER" tailscale serve clear "$OTHERHOST_SERVICE_NAME" >/dev/null 2>&1 || true
+}
+
+# Establish OTHERHOST as a stable, host-backed service in the control plane.
+# Retries create+advertise because DockTail's cleanup may delete the definition
+# during the brief window before the advertising host propagates. Once a host is
+# registered the serve config keeps it registered, so DockTail stops deleting it.
+setup_otherhost_service() {
+    local token="$1" attempt inner hc
+    for attempt in $(seq 1 6); do
+        api_create_service "$token" "$OTHERHOST_SERVICE_NAME" >/dev/null
+        advertise_otherhost_service
+        for inner in $(seq 1 5); do
+            sleep 2
+            hc=$(api_service_host_count "$token" "$OTHERHOST_SERVICE_NAME")
+            if [ "${hc:-0}" -ge 1 ] 2>/dev/null; then
+                return 0
+            fi
+            if [ "$(api_service_status "$token" "$OTHERHOST_SERVICE_NAME")" = "404" ]; then
+                break  # deleted mid-registration; recreate and retry
+            fi
+        done
+    done
     return 1
 }
 
@@ -581,10 +685,91 @@ else
 fi
 
 # ==============================================================================
-# 13. Log Health
+# 13. Control Plane Cleanup of Unused Services (DELETE_UNUSED_SERVICES=true)
+# ==============================================================================
+#
+# DockTail runs with DELETE_UNUSED_SERVICES=true in this stack. During each
+# reconcile it lists tailnet Service definitions and deletes the ones that no
+# host advertises anymore, while keeping:
+#   - services DockTail currently advertises (backed by a running container), and
+#   - services advertised by some other host (the multi-instance safety guard).
+#
+# We create two fixtures directly via the API to exercise both branches:
+#   - svc:e2e-orphan     : never advertised (zero hosts)  -> must be deleted
+#   - svc:e2e-otherhost  : advertised by the node (>=1 host) -> must be kept
+
+log "13. Control Plane Cleanup of Unused Services"
+
+API_TOKEN=$(mint_api_token)
+
+if [ -z "$API_TOKEN" ]; then
+    echo "  SKIP: no OAuth credentials available for Control Plane API assertions"
+else
+    # Capture whether DockTail created a definition for a running service, so the
+    # "preserved" assertion is decoupled from Control Plane creation timing.
+    proto_http_before=$(api_service_status "$API_TOKEN" "svc:e2e-proto-http")
+
+    echo "  --- Creating an unused (zero-host) service via API ---"
+    create_status=$(api_create_service "$API_TOKEN" "$ORPHAN_SERVICE_NAME")
+    if [ "$create_status" = "200" ]; then
+        pass "created $ORPHAN_SERVICE_NAME via API"
+    else
+        fail "failed to create $ORPHAN_SERVICE_NAME via API (status $create_status)"
+    fi
+
+    echo "  --- Creating a service advertised by the node (has a host) ---"
+    if setup_otherhost_service "$API_TOKEN"; then
+        pass "$OTHERHOST_SERVICE_NAME has at least one advertising host"
+    else
+        fail "$OTHERHOST_SERVICE_NAME never registered an advertising host"
+    fi
+
+    echo "  --- DockTail should delete the unused service ---"
+    orphan_deleted=0
+    for _ in $(seq 1 20); do
+        if [ "$(api_service_status "$API_TOKEN" "$ORPHAN_SERVICE_NAME")" = "404" ]; then
+            orphan_deleted=1
+            break
+        fi
+        sleep 2
+    done
+    if [ "$orphan_deleted" = "1" ]; then
+        pass "$ORPHAN_SERVICE_NAME deleted by DockTail (no advertising hosts)"
+    else
+        fail "$ORPHAN_SERVICE_NAME still exists; DockTail did not delete the unused service"
+    fi
+
+    echo "  --- DockTail must keep the service advertised by another host ---"
+    if [ "$(api_service_status "$API_TOKEN" "$OTHERHOST_SERVICE_NAME")" = "200" ]; then
+        pass "$OTHERHOST_SERVICE_NAME preserved (still advertised by a host)"
+    else
+        fail "$OTHERHOST_SERVICE_NAME was deleted despite having an advertising host"
+    fi
+
+    echo "  --- DockTail must keep the running container's service ---"
+    if [ "$proto_http_before" = "200" ]; then
+        if [ "$(api_service_status "$API_TOKEN" "svc:e2e-proto-http")" = "200" ]; then
+            pass "svc:e2e-proto-http preserved (DockTail is advertising it)"
+        else
+            fail "svc:e2e-proto-http was deleted despite being advertised by DockTail"
+        fi
+    else
+        echo "  SKIP: svc:e2e-proto-http has no Control Plane definition to check"
+    fi
+
+    wait_for_docktail_log "Deleting unused service definition"
+
+    echo "  --- Cleaning up cleanup-test fixtures ---"
+    clear_otherhost_service
+    api_delete_service "$API_TOKEN" "$OTHERHOST_SERVICE_NAME"
+    api_delete_service "$API_TOKEN" "$ORPHAN_SERVICE_NAME"
+fi
+
+# ==============================================================================
+# 14. Log Health
 # ==============================================================================
 
-log "13. DockTail Log Health"
+log "14. DockTail Log Health"
 docktail_logs=$(docker logs "$DOCKTAIL_CONTAINER" 2>&1)
 
 if grep -qE "FATAL|panic" <<<"$docktail_logs"; then

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -35,6 +36,7 @@ func main() {
 	tailscaleTailnet := getEnv("TAILSCALE_TAILNET", "-")
 	defaultTagsStr := getEnv("DEFAULT_SERVICE_TAGS", "tag:container")
 	ignoreServiceNamesStr := getEnv("IGNORE_SERVICE_NAMES", "")
+	deleteUnusedServices := getEnvBool("DELETE_UNUSED_SERVICES", false)
 
 	// Parse default tags
 	var defaultTags []string
@@ -62,6 +64,14 @@ func main() {
 
 	logCredentialWarnings(tailscaleAPIKey, tailscaleOAuthClientID, tailscaleOAuthClientSecret)
 
+	// The unused-service cleanup relies on the Control Plane API to inspect and
+	// delete service definitions. Without credentials it can never run, so warn
+	// loudly rather than silently ignoring the opt-in.
+	if deleteUnusedServices && apiSyncMethod == "disabled" {
+		log.Warn().
+			Msg("DELETE_UNUSED_SERVICES is enabled but no Tailscale API credentials are configured; unused-service cleanup will be skipped")
+	}
+
 	log.Info().
 		Dur("reconcile_interval", reconcileInterval).
 		Str("tailscale_socket", tailscaleSocket).
@@ -69,6 +79,7 @@ func main() {
 		Str("tailnet", tailscaleTailnet).
 		Strs("default_tags", defaultTags).
 		Strs("ignore_service_names", ignoreServiceNames).
+		Bool("delete_unused_services", deleteUnusedServices).
 		Msg("Configuration loaded")
 
 	// Create Docker client
@@ -82,12 +93,13 @@ func main() {
 
 	// Create Tailscale client
 	tailscaleClient := tailscale.NewClient(tailscale.ClientConfig{
-		SocketPath:         tailscaleSocket,
-		Tailnet:            tailscaleTailnet,
-		APIKey:             tailscaleAPIKey,
-		OAuthClientID:      tailscaleOAuthClientID,
-		OAuthClientSecret:  tailscaleOAuthClientSecret,
-		IgnoreServiceNames: ignoreServiceNames,
+		SocketPath:           tailscaleSocket,
+		Tailnet:              tailscaleTailnet,
+		APIKey:               tailscaleAPIKey,
+		OAuthClientID:        tailscaleOAuthClientID,
+		OAuthClientSecret:    tailscaleOAuthClientSecret,
+		IgnoreServiceNames:   ignoreServiceNames,
+		DeleteUnusedServices: deleteUnusedServices,
 	})
 
 	// Detect CLI/daemon version mismatch (common with host-mode Tailscale)
@@ -214,6 +226,20 @@ func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
 			Str("value", value).
 			Dur("default", defaultValue).
 			Msg("Failed to parse duration, using default")
+	}
+	return defaultValue
+}
+
+func getEnvBool(key string, defaultValue bool) bool {
+	if value := os.Getenv(key); value != "" {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			return parsed
+		}
+		log.Warn().
+			Str("key", key).
+			Str("value", value).
+			Bool("default", defaultValue).
+			Msg("Failed to parse bool, using default")
 	}
 	return defaultValue
 }

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -19,14 +19,15 @@ import (
 
 // Client handles Tailscale CLI interactions and API calls
 type Client struct {
-	socketPath      string
-	tailnet         string
-	baseURL         string
-	httpClient      *http.Client
-	apiSyncEnabled  bool
-	serverVersion   string // set when CLI/daemon version mismatch detected
-	managedFunnels  map[string]struct{}
-	ignoredServices map[string]struct{}
+	socketPath           string
+	tailnet              string
+	baseURL              string
+	httpClient           *http.Client
+	apiSyncEnabled       bool
+	serverVersion        string // set when CLI/daemon version mismatch detected
+	managedFunnels       map[string]struct{}
+	ignoredServices      map[string]struct{}
+	deleteUnusedServices bool
 }
 
 // ClientConfig holds configuration for creating a Tailscale client
@@ -37,17 +38,21 @@ type ClientConfig struct {
 	OAuthClientID      string
 	OAuthClientSecret  string
 	IgnoreServiceNames []string
+	// DeleteUnusedServices enables removal of tailnet Service definitions that
+	// are no longer advertised by any host during reconciliation.
+	DeleteUnusedServices bool
 }
 
 // NewClient creates a new Tailscale client
 // Prefers OAuth credentials over API key if both are provided
 func NewClient(cfg ClientConfig) *Client {
 	client := &Client{
-		socketPath:      cfg.SocketPath,
-		tailnet:         cfg.Tailnet,
-		baseURL:         "https://api.tailscale.com",
-		managedFunnels:  make(map[string]struct{}),
-		ignoredServices: make(map[string]struct{}),
+		socketPath:           cfg.SocketPath,
+		tailnet:              cfg.Tailnet,
+		baseURL:              "https://api.tailscale.com",
+		managedFunnels:       make(map[string]struct{}),
+		ignoredServices:      make(map[string]struct{}),
+		deleteUnusedServices: cfg.DeleteUnusedServices,
 	}
 
 	for _, serviceName := range cfg.IgnoreServiceNames {
@@ -306,6 +311,15 @@ func (c *Client) ReconcileServices(ctx context.Context, desiredServices []*appty
 			// Log error but do NOT return it - we don't want API failures to break local serving
 			log.Error().Err(err).Msg("Failed to sync service definitions to Tailscale API")
 		}
+
+		// Optionally delete tailnet Service definitions no host advertises anymore.
+		// Runs after syncing so freshly created services are already in the desired
+		// set and therefore excluded. Failures are non-blocking.
+		if c.deleteUnusedServices {
+			if err := c.deleteUnusedServiceDefinitions(ctx, desiredServices); err != nil {
+				log.Error().Err(err).Msg("Failed to delete unused service definitions")
+			}
+		}
 	}
 
 	return nil
@@ -455,6 +469,7 @@ func (c *Client) SyncServiceDefinition(ctx context.Context, serviceName string, 
 }
 
 type apiService struct {
+	Name  string   `json:"name"`
 	Addrs []string `json:"addrs"`
 	Tags  []string `json:"tags"`
 	Ports []string `json:"ports"`
@@ -496,6 +511,201 @@ func (c *Client) getService(ctx context.Context, serviceName string) (*apiServic
 	}
 
 	return &svc, nil
+}
+
+// listServices returns every Service definition configured in the tailnet.
+func (c *Client) listServices(ctx context.Context) ([]apiService, error) {
+	apiURL := fmt.Sprintf("%s/api/v2/tailnet/%s/services", c.baseURL, url.PathEscape(c.tailnet))
+
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GET request: %w", err)
+	}
+
+	log.Debug().
+		Str("method", "GET").
+		Str("url", apiURL).
+		Msg("Listing service definitions")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list services API returned error status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		VIPServices []apiService `json:"vipServices"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return result.VIPServices, nil
+}
+
+// serviceHost describes a device that is advertising a Service, as returned by
+// the "list devices hosting a Service" API.
+type serviceHost struct {
+	StableNodeID  string `json:"stableNodeID"`
+	ApprovalLevel string `json:"approvalLevel"`
+	Configured    string `json:"configured"`
+}
+
+// listServiceHosts returns the devices currently advertising the given Service.
+// An empty slice means no host is advertising it, i.e. the Service is unused.
+func (c *Client) listServiceHosts(ctx context.Context, serviceName string) ([]serviceHost, error) {
+	apiURL := fmt.Sprintf("%s/api/v2/tailnet/%s/services/%s/devices", c.baseURL, url.PathEscape(c.tailnet), url.PathEscape(serviceName))
+
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GET request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list service hosts API returned error status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Hosts []serviceHost `json:"hosts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return result.Hosts, nil
+}
+
+// deleteService removes a Service definition from the tailnet Control Plane.
+// A 404 is treated as success since the goal (the Service no longer exists) is met.
+func (c *Client) deleteService(ctx context.Context, serviceName string) error {
+	apiURL := fmt.Sprintf("%s/api/v2/tailnet/%s/services/%s", c.baseURL, url.PathEscape(c.tailnet), url.PathEscape(serviceName))
+
+	req, err := http.NewRequestWithContext(ctx, "DELETE", apiURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create DELETE request: %w", err)
+	}
+
+	log.Debug().
+		Str("method", "DELETE").
+		Str("url", apiURL).
+		Msg("Deleting service definition")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("DELETE request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("delete service API returned error status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// deleteUnusedServiceDefinitions removes tailnet Service definitions that DockTail
+// no longer advertises and that no other host is advertising either.
+//
+// It is deliberately conservative so it is safe to run from multiple DockTail
+// instances against the same tailnet:
+//   - Services DockTail currently wants (the desired set) are never touched. This
+//     also protects a Service created earlier in this same reconcile cycle before
+//     its advertising host has propagated to the Control Plane.
+//   - Services listed in IGNORE_SERVICE_NAMES are never touched.
+//   - A Service is deleted only when the Control Plane reports zero hosts advertising
+//     it. A Service advertised by any other node/instance reports at least one host
+//     and is left alone.
+//   - Any API error while listing services or hosts aborts deletion for that Service;
+//     DockTail never deletes under uncertainty.
+func (c *Client) deleteUnusedServiceDefinitions(ctx context.Context, desiredServices []*apptypes.ContainerService) error {
+	desired := make(map[string]struct{})
+	for _, svc := range desiredServices {
+		if !svc.ServiceEnabled {
+			continue
+		}
+		desired[normalizeServiceName(svc.ServiceName)] = struct{}{}
+	}
+
+	services, err := c.listServices(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list services: %w", err)
+	}
+
+	log.Info().
+		Int("service_count", len(services)).
+		Msg("Checking tailnet for unused service definitions")
+
+	deleted := 0
+	var lastErr error
+
+	for _, svc := range services {
+		name := svc.Name
+		if !isManagedService(name) {
+			continue
+		}
+		if _, ok := desired[normalizeServiceName(name)]; ok {
+			// DockTail advertises this service; keep it.
+			continue
+		}
+		if c.shouldIgnoreService(name) {
+			log.Debug().
+				Str("service", name).
+				Msg("Skipping unused-service cleanup for ignored service")
+			continue
+		}
+
+		hosts, err := c.listServiceHosts(ctx, name)
+		if err != nil {
+			log.Warn().
+				Err(err).
+				Str("service", name).
+				Msg("Failed to check service hosts, skipping deletion")
+			lastErr = err
+			continue
+		}
+		if len(hosts) > 0 {
+			log.Debug().
+				Str("service", name).
+				Int("host_count", len(hosts)).
+				Msg("Service still advertised by at least one host, keeping")
+			continue
+		}
+
+		log.Info().
+			Str("service", name).
+			Msg("Deleting unused service definition (no advertising hosts)")
+
+		if err := c.deleteService(ctx, name); err != nil {
+			log.Error().
+				Err(err).
+				Str("service", name).
+				Msg("Failed to delete unused service definition")
+			lastErr = err
+			continue
+		}
+		deleted++
+	}
+
+	if deleted > 0 {
+		log.Info().
+			Int("deleted", deleted).
+			Msg("Deleted unused service definitions")
+	}
+
+	return lastErr
 }
 
 // CleanupAllServices removes all services and funnels managed by DockTail


### PR DESCRIPTION
## Summary

Adds an opt-in `DELETE_UNUSED_SERVICES` flag (disabled by default) that lets DockTail remove tailnet Service definitions that no host advertises anymore. The main motivation is making the e2e tests more representative by exercising the full create → advertise → delete lifecycle and keeping the shared CI tailnet clean, but it's a generally useful cleanup for anyone who wants it.

## Behaviour

During each reconciliation, for every Service definition in the tailnet DockTail:

1. **Keeps** it if DockTail currently advertises it (backed by a running container).
2. **Keeps** it if the name is in `IGNORE_SERVICE_NAMES`.
3. Asks the Control Plane which hosts advertise it. If **≥1 host** advertises it → **keep**.
4. **Deletes** it only when **no host** advertises it.

Because the decision is based on the tailnet-wide advertiser count, this is **safe to enable on multiple DockTail instances at once**: a service advertised by any other host/instance always reports at least one host and is never deleted. DockTail also skips deletion whenever an API call fails, so it never deletes under uncertainty.

Cleanup runs **only during reconciliation, never on shutdown**, so restarting DockTail does not delete and recreate the services of still-running containers (which would churn their VIP addresses).

> When enabled, DockTail may also delete definitions it did not create if they have zero advertising hosts (e.g. a service defined in the admin console but never advertised). `IGNORE_SERVICE_NAMES` protects such names.

## Implementation

- New Control Plane API calls in `tailscale/client.go`: `listServices` (`GET .../services`), `listServiceHosts` (`GET .../services/{name}/devices`), `deleteService` (`DELETE .../services/{name}`).
- `getEnvBool` helper + `DELETE_UNUSED_SERVICES` wired through `ClientConfig`/`Client`.
- Runs after `syncServiceDefinitions`, gated on the flag and API credentials; failures are non-blocking.
- Uses the same OAuth scopes DockTail already requires (`Services: Write`, `Devices: Core: Write`).

## E2E

- `DELETE_UNUSED_SERVICES=true` in the e2e stack.
- New section 13 creates two fixtures directly via the API — `svc:e2e-orphan` (never advertised, zero hosts) and `svc:e2e-otherhost` (advertised by the node, ≥1 host) — and asserts DockTail deletes the orphan while keeping the host-backed service and the running containers' services.
- Teardown sweeps leftover `svc:e2e-*` definitions so repeated CI runs stay clean.

## Docs

Updated `docs/06-reference.md` (env var + cleanup behavior), `docs/07-how-it-works.md` (flow), `docs/03-tailscale-admin.md` (scopes note), `.env.example`, and `README.md`.

## Testing

`go build`, `go vet`, and `gofmt` are clean. The e2e workflow validates the feature end-to-end against a real tailnet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in cleanup option to remove unused Tailscale service definitions when no host is advertising them.
  * Updated setup and reference docs to explain the new environment setting and how it behaves safely with multiple instances.

* **Bug Fixes**
  * Reconciliation now skips cleanup when required API credentials are unavailable, with clearer startup warnings.
  * Added end-to-end coverage for deleting orphaned services while preserving active ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->