### PR TITLE
test(e2e): verify custom tags land on the service via Control Plane API

### DIFF
--- a/e2e.sh
+++ b/e2e.sh
@@ -316,6 +316,36 @@ api_service_host_count() {
         | jq -r '.hosts | length' 2>/dev/null || echo "0"
 }
 
+# Assert that a Control Plane service definition carries exactly the expected
+# tags (order-independent). The tags a service carries are NOT visible in
+# `tailscale serve status`; they only live in the service definition on the
+# control plane, so this is the only way to actually verify tag parsing.
+# Retries because DockTail creates the definition asynchronously during
+# reconciliation. Usage: assert_service_tags <token> <service-name> <tag>...
+assert_service_tags() {
+    local token="$1" name="svc:$2"
+    shift 2
+    local expected actual=""
+    expected=$(jq -rn --args '$ARGS.positional | sort | join(",")' "$@")
+
+    local attempt
+    for attempt in $(seq 1 20); do
+        actual=$(curl -s -H "Authorization: Bearer ${token}" \
+            "${API_BASE}/tailnet/${API_TAILNET}/services/${name}" 2>/dev/null \
+            | jq -r '(.tags // []) | sort | join(",")' 2>/dev/null || true)
+        if [ -n "$actual" ]; then
+            break
+        fi
+        sleep 2
+    done
+
+    if [ "$actual" = "$expected" ]; then
+        pass "$name has tags [$expected]"
+    else
+        fail "$name expected tags [$expected], got [${actual:-<none>}]"
+    fi
+}
+
 # Delete a service definition (best effort).
 api_delete_service() {
     local token="$1" name="$2"
@@ -505,9 +535,22 @@ assert_funnel_active        "8443"
 # ==============================================================================
 
 log "5. Custom Tags"
-# Tags aren't in serve status, but we verify the service was created
-# (tag validation would need API access)
 assert_service_exists       "e2e-custom-tags"
+
+# The container sets `docktail.tags=tag:web,tag:production` (comma-separated).
+# Verify BOTH tags actually landed on the service definition in the control
+# plane. This guards the comma-splitting tag parser: a regression that dropped
+# the second tag, mis-split the value, or ignored the label would be caught
+# here (an exact, order-independent match), whereas the existence check above
+# would still pass. The tags are only visible via the Control Plane API, not
+# `tailscale serve status`, so this needs an OAuth token — without one we fail
+# loudly rather than silently skip the verification.
+CUSTOM_TAGS_TOKEN=$(mint_api_token)
+if [ -z "$CUSTOM_TAGS_TOKEN" ]; then
+    fail "no OAuth credentials available to verify custom tags via Control Plane API"
+else
+    assert_service_tags "$CUSTOM_TAGS_TOKEN" "e2e-custom-tags" "tag:web" "tag:production"
+fi
 
 # ==============================================================================
 # 6. Multiple Ports

--- a/e2e.sh
+++ b/e2e.sh
@@ -320,8 +320,10 @@ api_service_host_count() {
 # tags (order-independent). The tags a service carries are NOT visible in
 # `tailscale serve status`; they only live in the service definition on the
 # control plane, so this is the only way to actually verify tag parsing.
-# Retries because DockTail creates the definition asynchronously during
-# reconciliation. Usage: assert_service_tags <token> <service-name> <tag>...
+# Polls until the tags converge on the expected set (the definition is created
+# asynchronously during reconciliation), so the check reflects the reconciled
+# result rather than the first partial/empty response. Usage:
+# assert_service_tags <token> <service-name> <tag>...
 assert_service_tags() {
     local token="$1" name="svc:$2"
     shift 2
@@ -333,7 +335,7 @@ assert_service_tags() {
         actual=$(curl -s -H "Authorization: Bearer ${token}" \
             "${API_BASE}/tailnet/${API_TAILNET}/services/${name}" 2>/dev/null \
             | jq -r '(.tags // []) | sort | join(",")' 2>/dev/null || true)
-        if [ -n "$actual" ]; then
+        if [ "$actual" = "$expected" ]; then
             break
         fi
         sleep 2


### PR DESCRIPTION
## What

The **Custom Tags** e2e case (`test-custom-tags`) sets `docktail.tags=tag:web,tag:production` but only asserted that the service *existed*:

```bash
# Tags aren't in serve status, but we verify the service was created
# (tag validation would need API access)
assert_service_exists "e2e-custom-tags"
```

So a regression that dropped the second tag, mis-split the comma-separated value, or ignored the label entirely would **still pass** — the comma-splitting parser at `docker/client.go` had no real coverage.

## Change

Add `assert_service_tags`, which queries the service definition on the Tailscale **Control Plane API** (`GET /tailnet/{tailnet}/services/{name}`) — tags live there and are *not* exposed in `tailscale serve status`, which is why the old check couldn't see them. It asserts an **exact, order-independent** match against both expected tags, so it catches:

- a dropped tag (only `tag:web` kept),
- a mis-split value (`tag:web,tag:production` treated as one tag),
- an ignored label (falls back to the default `tag:ci-test-container`),
- unexpected extra tags.

It reuses the existing OAuth token minting (`mint_api_token`) and API helper pattern already used by the cleanup tests, and retries while DockTail asynchronously creates the definition during reconciliation.

Per the request, the check **fails loudly** if no OAuth token is available rather than silently skipping — the verification can't be bypassed into a false pass.

## Notes

- Test-only change; no user-facing behavior, labels, or docs affected.
- `bash -n` syntax-checked; jq normalization verified to produce identical order-independent output for expected vs. actual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened end-to-end validation for custom tags by confirming the expected tags are present on the control plane service definition.
  * Added retry-based polling to handle asynchronous tag reconciliation, with order-independent tag matching.
  * Improved robustness by minting an OAuth token for tag verification and failing clearly when OAuth credentials are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->