### PR TITLE
feat: set Tailscale service description via label

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -320,6 +320,26 @@ services:
       - "docktail.service.service-port=80"
       - "docktail.service.service-protocol=http"
 
+  # ============================================================================
+  # 10. Service Description (synced to Control Plane "comment", issue #60)
+  # ============================================================================
+
+  # Primary service with a description plus an indexed service with its own
+  # description; both are synced to the Service definition's "comment" field.
+  test-description:
+    image: nginx:alpine
+    container_name: e2e-description
+    restart: "no"
+    labels:
+      - "docktail.service.enable=true"
+      - "docktail.service.name=e2e-description"
+      - "docktail.service.port=80"
+      - "docktail.service.description=E2E Bookmark Manager"
+      - "docktail.service.1.name=e2e-description-secondary"
+      - "docktail.service.1.port=80"
+      - "docktail.service.1.service-port=8080"
+      - "docktail.service.1.description=E2E Secondary Service"
+
 networks:
   backend:
 

--- a/docker/client.go
+++ b/docker/client.go
@@ -487,16 +487,17 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 		cctx.destIP = destIP
 
 		primary := &apptypes.ContainerService{
-			ContainerID:     cctx.containerID[:12],
-			ContainerName:   cctx.containerName,
-			ServiceEnabled:  true,
-			ServiceName:     serviceName,
-			Port:            port,
-			TargetPort:      destPort,
-			ServiceProtocol: serviceProtocol,
-			Protocol:        protocol,
-			Tags:            tags,
-			IPAddress:       destIP,
+			ContainerID:        cctx.containerID[:12],
+			ContainerName:      cctx.containerName,
+			ServiceEnabled:     true,
+			ServiceName:        serviceName,
+			ServiceDescription: labels[apptypes.LabelDescription],
+			Port:               port,
+			TargetPort:         destPort,
+			ServiceProtocol:    serviceProtocol,
+			Protocol:           protocol,
+			Tags:               tags,
+			IPAddress:          destIP,
 		}
 		result = append(result, primary)
 
@@ -654,17 +655,18 @@ func (c *Client) parseIndexedPorts(
 		}
 
 		svc := &apptypes.ContainerService{
-			ContainerID:     cctx.containerID[:12],
-			ContainerName:   cctx.containerName,
-			ServiceEnabled:  true,
-			ServiceName:     idxServiceName,
-			Port:            servicePort,
-			TargetPort:      idxDestPort,
-			ServiceProtocol: serviceProtocol,
-			Protocol:        protocol,
-			Tags:            cctx.tags,
-			IPAddress:       idxDestIP,
-			FunnelEnabled:   false,
+			ContainerID:        cctx.containerID[:12],
+			ContainerName:      cctx.containerName,
+			ServiceEnabled:     true,
+			ServiceName:        idxServiceName,
+			ServiceDescription: labels[prefix+"description"],
+			Port:               servicePort,
+			TargetPort:         idxDestPort,
+			ServiceProtocol:    serviceProtocol,
+			Protocol:           protocol,
+			Tags:               cctx.tags,
+			IPAddress:          idxDestIP,
+			FunnelEnabled:      false,
 		}
 
 		services = append(services, svc)

--- a/docs/04-labels.md
+++ b/docs/04-labels.md
@@ -25,6 +25,7 @@ Set `docktail.service.direct=false` to use published host ports instead. This is
 | `docktail.service.enable` | Yes | - | Enable a private Tailscale service for the container. |
 | `docktail.service.name` | Yes | - | Service name, such as `web` or `api`. |
 | `docktail.service.port` | Yes | - | Backend container port to proxy to. |
+| `docktail.service.description` | No | - | Human-readable description shown for the service in the Tailscale admin panel. Requires API credentials (synced to the Service definition's `comment`). |
 | `docktail.service.direct` | No | `true` | Proxy directly to container IP instead of requiring a published host port. |
 | `docktail.service.network` | No | `bridge` or first available | Docker network used for direct container IP detection. |
 | `docktail.service.protocol` | No | Smart | Backend protocol. |
@@ -54,7 +55,7 @@ services:
       - "docktail.service.1.port=8001"
 ```
 
-Each indexed service requires its own `name` and `port`. Per-index overridable labels are `name`, `port`, `service-port`, `protocol`, and `service-protocol`. Tags and network settings are inherited from the primary service config.
+Each indexed service requires its own `name` and `port`. Per-index overridable labels are `name`, `port`, `service-port`, `protocol`, `service-protocol`, and `description`. Tags and network settings are inherited from the primary service config.
 
 ### Funnel Labels
 

--- a/docs/05-examples.md
+++ b/docs/05-examples.md
@@ -16,6 +16,21 @@ services:
 
 Access it at `http://web.your-tailnet.ts.net`.
 
+### Service With A Description
+
+Add a description to label the service in the Tailscale admin panel. Requires API credentials (OAuth or API key), which DockTail syncs to the Service definition's `comment`.
+
+```yaml
+services:
+  linkding:
+    image: sissbruecker/linkding:latest
+    labels:
+      - "docktail.service.enable=true"
+      - "docktail.service.name=linkding"
+      - "docktail.service.port=9090"
+      - "docktail.service.description=Bookmark Manager"
+```
+
 ### HTTPS With Auto TLS
 
 ```yaml

--- a/e2e.sh
+++ b/e2e.sh
@@ -782,7 +782,8 @@ fi
 # service in the Tailscale admin panel. DockTail syncs it to the Service
 # definition's "comment" field via the Control Plane API, so it is only
 # verifiable when API credentials are configured. Indexed services carry their
-# own description independently of the primary service.
+# own description independently of the primary service. Covers both the initial
+# sync and a later description change being reflected in the comment.
 
 log "14. Service Description (issue #60)"
 
@@ -822,6 +823,32 @@ else
         pass "svc:e2e-description-secondary comment set to 'E2E Secondary Service'"
     else
         fail "svc:e2e-description-secondary comment not synced (got '$(api_service_comment "$API_TOKEN" "svc:e2e-description-secondary")')"
+    fi
+
+    echo "  --- Changing the description is reflected in the Control Plane comment ---"
+    docker stop e2e-description >/dev/null 2>&1 || true
+    docker rm e2e-description >/dev/null 2>&1 || true
+    docker run -d \
+        --name e2e-description \
+        --restart no \
+        --label "docktail.service.enable=true" \
+        --label "docktail.service.name=e2e-description" \
+        --label "docktail.service.port=80" \
+        --label "docktail.service.description=E2E Updated Description" \
+        nginx:alpine >/dev/null 2>&1
+
+    desc_updated=0
+    for _ in $(seq 1 20); do
+        if [ "$(api_service_comment "$API_TOKEN" "svc:e2e-description")" = "E2E Updated Description" ]; then
+            desc_updated=1
+            break
+        fi
+        sleep 2
+    done
+    if [ "$desc_updated" = "1" ]; then
+        pass "svc:e2e-description comment changed to 'E2E Updated Description'"
+    else
+        fail "svc:e2e-description comment not updated (got '$(api_service_comment "$API_TOKEN" "svc:e2e-description")')"
     fi
 fi
 

--- a/e2e.sh
+++ b/e2e.sh
@@ -308,6 +308,14 @@ api_create_service() {
         "${API_BASE}/tailnet/${API_TAILNET}/services/${name}" 2>/dev/null || echo "000"
 }
 
+# Print the "comment" (description) of a service definition, empty if unset/gone.
+api_service_comment() {
+    local token="$1" name="$2"
+    curl -s -H "Authorization: Bearer ${token}" \
+        "${API_BASE}/tailnet/${API_TAILNET}/services/${name}" 2>/dev/null \
+        | jq -r '.comment // empty' 2>/dev/null || echo ""
+}
+
 # Count hosts currently advertising a service (0 = unused).
 api_service_host_count() {
     local token="$1" name="$2"
@@ -766,10 +774,62 @@ else
 fi
 
 # ==============================================================================
-# 14. Log Health
+# 14. Service Description (synced to Control Plane "comment", issue #60)
+# ==============================================================================
+#
+# https://github.com/marvinvr/docktail/issues/60
+# docktail.service.description sets the human-readable description shown per
+# service in the Tailscale admin panel. DockTail syncs it to the Service
+# definition's "comment" field via the Control Plane API, so it is only
+# verifiable when API credentials are configured. Indexed services carry their
+# own description independently of the primary service.
+
+log "14. Service Description (issue #60)"
+
+echo "  --- Pre-check: described services exist locally ---"
+refresh_serve_status
+assert_service_exists       "e2e-description"
+assert_service_exists       "e2e-description-secondary"
+
+if [ -z "${API_TOKEN:-}" ]; then
+    echo "  SKIP: no OAuth credentials available for Control Plane API assertions"
+else
+    echo "  --- Primary service description synced to Control Plane comment ---"
+    desc_synced=0
+    for _ in $(seq 1 20); do
+        if [ "$(api_service_comment "$API_TOKEN" "svc:e2e-description")" = "E2E Bookmark Manager" ]; then
+            desc_synced=1
+            break
+        fi
+        sleep 2
+    done
+    if [ "$desc_synced" = "1" ]; then
+        pass "svc:e2e-description comment set to 'E2E Bookmark Manager'"
+    else
+        fail "svc:e2e-description comment not synced (got '$(api_service_comment "$API_TOKEN" "svc:e2e-description")')"
+    fi
+
+    echo "  --- Indexed service description synced independently ---"
+    idx_desc_synced=0
+    for _ in $(seq 1 20); do
+        if [ "$(api_service_comment "$API_TOKEN" "svc:e2e-description-secondary")" = "E2E Secondary Service" ]; then
+            idx_desc_synced=1
+            break
+        fi
+        sleep 2
+    done
+    if [ "$idx_desc_synced" = "1" ]; then
+        pass "svc:e2e-description-secondary comment set to 'E2E Secondary Service'"
+    else
+        fail "svc:e2e-description-secondary comment not synced (got '$(api_service_comment "$API_TOKEN" "svc:e2e-description-secondary")')"
+    fi
+fi
+
+# ==============================================================================
+# 15. Log Health
 # ==============================================================================
 
-log "14. DockTail Log Health"
+log "15. DockTail Log Health"
 docktail_logs=$(docker logs "$DOCKTAIL_CONTAINER" 2>&1)
 
 if grep -qE "FATAL|panic" <<<"$docktail_logs"; then

--- a/mmux.yaml
+++ b/mmux.yaml
@@ -1,0 +1,25 @@
+# mmux workspace config.
+# Run `mmux` in this directory to open (or reattach to) the session.
+# New here? Run `mmux docs` for the full guide, or visit https://mmux.org.
+# `name` is optional — it defaults to this directory's name.
+# name: my-workspace
+
+# Agents: interactive programs you spawn on demand from the sidebar.
+# agents:
+#   - name: Claude
+#     cmd: claude
+#     args: ["--dangerously-skip-permissions"]
+
+# Processes: commands you start/stop and watch. cwd is relative to this file.
+# processes:
+#   - name: Dev server
+#     cmd: npm
+#     args: ["run", "dev"]
+#     autostart: false
+
+# Linked projects: other projects to show alongside this one in the same
+# workspace — any directories you want grouped together (extra clones, a
+# related repo, a service), each its own sidebar group. One level deep,
+# de-duplicated by path.
+linked-projects:
+  - ../docktail2

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -325,13 +325,20 @@ func (c *Client) ReconcileServices(ctx context.Context, desiredServices []*appty
 	return nil
 }
 
-// syncServiceDefinitions syncs all desired services to the Tailscale Control Plane
-func (c *Client) syncServiceDefinitions(ctx context.Context, services []*apptypes.ContainerService) error {
-	// Deduplicate by service name and aggregate all ports per service
-	type serviceDef struct {
-		Tags  []string
-		Ports []string
-	}
+// serviceDef is the deduplicated, per-service-name view of the desired state
+// that gets synced to the Control Plane.
+type serviceDef struct {
+	Tags        []string
+	Ports       []string
+	Description string
+}
+
+// aggregateServiceDefinitions deduplicates the desired services by name,
+// aggregating all ports per service and carrying the tags and description.
+// A container can define several services (primary + indexed) and several
+// containers can back the same service name, so ports are merged and the first
+// non-empty description wins.
+func aggregateServiceDefinitions(services []*apptypes.ContainerService) map[string]*serviceDef {
 	uniqueServices := make(map[string]*serviceDef)
 
 	for _, svc := range services {
@@ -340,8 +347,10 @@ func (c *Client) syncServiceDefinitions(ctx context.Context, services []*apptype
 		}
 		def, exists := uniqueServices[svc.ServiceName]
 		if !exists {
-			def = &serviceDef{Tags: svc.Tags}
+			def = &serviceDef{Tags: svc.Tags, Description: svc.ServiceDescription}
 			uniqueServices[svc.ServiceName] = def
+		} else if def.Description == "" {
+			def.Description = svc.ServiceDescription
 		}
 		// Add port if not already present
 		found := false
@@ -356,13 +365,20 @@ func (c *Client) syncServiceDefinitions(ctx context.Context, services []*apptype
 		}
 	}
 
+	return uniqueServices
+}
+
+// syncServiceDefinitions syncs all desired services to the Tailscale Control Plane
+func (c *Client) syncServiceDefinitions(ctx context.Context, services []*apptypes.ContainerService) error {
+	uniqueServices := aggregateServiceDefinitions(services)
+
 	log.Info().
 		Int("unique_services", len(uniqueServices)).
 		Msg("Syncing service definitions to Control Plane")
 
 	var failed []string
 	for name, def := range uniqueServices {
-		if err := c.SyncServiceDefinition(ctx, name, def.Tags, def.Ports); err != nil {
+		if err := c.SyncServiceDefinition(ctx, name, def.Tags, def.Ports, def.Description); err != nil {
 			failed = append(failed, name)
 			log.Error().
 				Err(err).
@@ -380,8 +396,11 @@ func (c *Client) syncServiceDefinitions(ctx context.Context, services []*apptype
 }
 
 // SyncServiceDefinition ensures a service definition exists in the Tailscale API.
-// Only creates if the service doesn't exist. Does NOT update existing services.
-func (c *Client) SyncServiceDefinition(ctx context.Context, serviceName string, tags []string, ports []string) error {
+// It creates the service (with an optional description) if it doesn't exist. For
+// an already-existing service it does NOT touch tags or ports, but it does
+// reconcile the description (the admin-panel "comment") when a description label
+// is set and differs from the current value.
+func (c *Client) SyncServiceDefinition(ctx context.Context, serviceName string, tags []string, ports []string, description string) error {
 	if !strings.HasPrefix(serviceName, "svc:") {
 		serviceName = "svc:" + serviceName
 	}
@@ -392,23 +411,39 @@ func (c *Client) SyncServiceDefinition(ctx context.Context, serviceName string, 
 		return fmt.Errorf("failed to get service details: %w", err)
 	}
 
-	// If service already exists, skip creation
+	// If service already exists, only reconcile the description. Tags and ports
+	// are intentionally left untouched to avoid clobbering manual changes.
 	if existing != nil {
-		log.Debug().
+		if description == "" || existing.Comment == description {
+			log.Debug().
+				Str("service", serviceName).
+				Strs("existing_tags", existing.Tags).
+				Strs("existing_ports", existing.Ports).
+				Msg("Service already exists in Control Plane, skipping creation")
+			return nil
+		}
+
+		log.Info().
 			Str("service", serviceName).
-			Strs("existing_tags", existing.Tags).
-			Strs("existing_ports", existing.Ports).
-			Msg("Service already exists in Control Plane, skipping creation")
-		return nil
+			Str("description", description).
+			Msg("Updating service description in Control Plane")
+
+		payload := map[string]interface{}{
+			"name":    serviceName,
+			"addrs":   existing.Addrs,
+			"tags":    existing.Tags,
+			"ports":   existing.Ports,
+			"comment": description,
+		}
+		return c.putService(ctx, serviceName, payload)
 	}
 
 	// Service doesn't exist, create it
 	log.Info().
 		Str("service", serviceName).
 		Strs("tags", tags).
+		Str("description", description).
 		Msg("Creating new service definition in Control Plane")
-
-	apiURL := fmt.Sprintf("%s/api/v2/tailnet/%s/services/%s", c.baseURL, url.PathEscape(c.tailnet), url.PathEscape(serviceName))
 
 	// Tailscale API requires "ports" to be present.
 	if len(ports) == 0 {
@@ -426,6 +461,25 @@ func (c *Client) SyncServiceDefinition(ctx context.Context, serviceName string, 
 		"tags":  tags,
 		"ports": portStrs,
 	}
+	if description != "" {
+		payload["comment"] = description
+	}
+
+	if err := c.putService(ctx, serviceName, payload); err != nil {
+		return err
+	}
+
+	log.Info().
+		Str("service", serviceName).
+		Strs("tags", tags).
+		Msg("Successfully created service definition in Control Plane")
+
+	return nil
+}
+
+// putService PUTs a service definition payload to the Control Plane API.
+func (c *Client) putService(ctx context.Context, serviceName string, payload map[string]interface{}) error {
+	apiURL := fmt.Sprintf("%s/api/v2/tailnet/%s/services/%s", c.baseURL, url.PathEscape(c.tailnet), url.PathEscape(serviceName))
 
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -460,19 +514,15 @@ func (c *Client) SyncServiceDefinition(ctx context.Context, serviceName string, 
 		return fmt.Errorf("API returned error status %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	log.Info().
-		Str("service", serviceName).
-		Strs("tags", tags).
-		Msg("Successfully created service definition in Control Plane")
-
 	return nil
 }
 
 type apiService struct {
-	Name  string   `json:"name"`
-	Addrs []string `json:"addrs"`
-	Tags  []string `json:"tags"`
-	Ports []string `json:"ports"`
+	Name    string   `json:"name"`
+	Addrs   []string `json:"addrs"`
+	Tags    []string `json:"tags"`
+	Ports   []string `json:"ports"`
+	Comment string   `json:"comment"`
 }
 
 // getService fetches the existing service definition from the Tailscale API

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -1,0 +1,92 @@
+package tailscale
+
+import (
+	"testing"
+
+	apptypes "github.com/marvinvr/docktail/types"
+)
+
+func TestAggregateServiceDefinitions(t *testing.T) {
+	tests := []struct {
+		name     string
+		services []*apptypes.ContainerService
+		expected map[string]*serviceDef
+	}{
+		{
+			name: "carries description onto the service definition",
+			services: []*apptypes.ContainerService{
+				{ServiceEnabled: true, ServiceName: "linkding", Port: "443", Tags: []string{"tag:container"}, ServiceDescription: "Bookmark Manager"},
+			},
+			expected: map[string]*serviceDef{
+				"linkding": {Tags: []string{"tag:container"}, Ports: []string{"443"}, Description: "Bookmark Manager"},
+			},
+		},
+		{
+			name: "empty description stays empty",
+			services: []*apptypes.ContainerService{
+				{ServiceEnabled: true, ServiceName: "web", Port: "80", Tags: []string{"tag:container"}},
+			},
+			expected: map[string]*serviceDef{
+				"web": {Tags: []string{"tag:container"}, Ports: []string{"80"}, Description: ""},
+			},
+		},
+		{
+			name: "aggregates ports and keeps first non-empty description per service",
+			services: []*apptypes.ContainerService{
+				{ServiceEnabled: true, ServiceName: "web", Port: "443", ServiceDescription: ""},
+				{ServiceEnabled: true, ServiceName: "web", Port: "8080", ServiceDescription: "Primary Web UI"},
+				{ServiceEnabled: true, ServiceName: "web", Port: "443", ServiceDescription: "ignored duplicate"},
+			},
+			expected: map[string]*serviceDef{
+				"web": {Ports: []string{"443", "8080"}, Description: "Primary Web UI"},
+			},
+		},
+		{
+			name: "indexed services each keep their own description",
+			services: []*apptypes.ContainerService{
+				{ServiceEnabled: true, ServiceName: "qbittorrent", Port: "8000", ServiceDescription: "Torrent client"},
+				{ServiceEnabled: true, ServiceName: "bitmagnet", Port: "8001", ServiceDescription: "DHT crawler"},
+			},
+			expected: map[string]*serviceDef{
+				"qbittorrent": {Ports: []string{"8000"}, Description: "Torrent client"},
+				"bitmagnet":   {Ports: []string{"8001"}, Description: "DHT crawler"},
+			},
+		},
+		{
+			name: "disabled services are ignored",
+			services: []*apptypes.ContainerService{
+				{ServiceEnabled: false, ServiceName: "funnel-only", Port: "443", ServiceDescription: "should be skipped"},
+			},
+			expected: map[string]*serviceDef{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := aggregateServiceDefinitions(tt.services)
+
+			if len(got) != len(tt.expected) {
+				t.Fatalf("got %d services, want %d", len(got), len(tt.expected))
+			}
+
+			for name, wantDef := range tt.expected {
+				gotDef, ok := got[name]
+				if !ok {
+					t.Fatalf("missing service %q", name)
+				}
+				if gotDef.Description != wantDef.Description {
+					t.Errorf("service %q description = %q, want %q", name, gotDef.Description, wantDef.Description)
+				}
+				if len(gotDef.Ports) != len(wantDef.Ports) {
+					t.Errorf("service %q ports = %v, want %v", name, gotDef.Ports, wantDef.Ports)
+				} else {
+					for i, p := range wantDef.Ports {
+						if gotDef.Ports[i] != p {
+							t.Errorf("service %q ports[%d] = %q, want %q", name, i, gotDef.Ports[i], p)
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -2,22 +2,23 @@ package types
 
 // ContainerService represents a parsed container with its Tailscale service configuration
 type ContainerService struct {
-	ContainerID      string
-	ContainerName    string
-	ServiceEnabled   bool
-	ServiceName      string
-	Port             string   // Tailscale service port (e.g., "443")
-	TargetPort       string   // Container/host port to proxy to (e.g., "9080")
-	ServiceProtocol  string   // Protocol Tailscale uses (e.g., "https", "http", "tcp")
-	Protocol         string   // Protocol the container speaks (e.g., "http", "https", "tcp")
-	Tags             []string // Tailscale service tags (e.g., ["tag:container", "tag:web"])
-	IPAddress        string
-	FunnelEnabled    bool   // Enable Tailscale Funnel (public internet access)
-	FunnelPort       string // Container port for funnel (separate from service port)
-	FunnelTargetPort string // Host port that maps to FunnelPort
-	FunnelFunnelPort string // Public-facing port (443, 8443, or 10000 for HTTPS)
-	FunnelProtocol   string // Funnel protocol (https, tcp, tls-terminated-tcp)
-	FunnelPath       string // HTTP(S) Funnel path (for example "/" or "/webhook")
+	ContainerID        string
+	ContainerName      string
+	ServiceEnabled     bool
+	ServiceName        string
+	ServiceDescription string   // Human-readable Service description synced to the Tailscale Control Plane (admin panel "comment")
+	Port               string   // Tailscale service port (e.g., "443")
+	TargetPort         string   // Container/host port to proxy to (e.g., "9080")
+	ServiceProtocol    string   // Protocol Tailscale uses (e.g., "https", "http", "tcp")
+	Protocol           string   // Protocol the container speaks (e.g., "http", "https", "tcp")
+	Tags               []string // Tailscale service tags (e.g., ["tag:container", "tag:web"])
+	IPAddress          string
+	FunnelEnabled      bool   // Enable Tailscale Funnel (public internet access)
+	FunnelPort         string // Container port for funnel (separate from service port)
+	FunnelTargetPort   string // Host port that maps to FunnelPort
+	FunnelFunnelPort   string // Public-facing port (443, 8443, or 10000 for HTTPS)
+	FunnelProtocol     string // Funnel protocol (https, tcp, tls-terminated-tcp)
+	FunnelPath         string // HTTP(S) Funnel path (for example "/" or "/webhook")
 }
 
 // TailscaleServiceConfig represents the JSON structure for Tailscale service configuration
@@ -35,6 +36,7 @@ type ServiceDefinition struct {
 const (
 	LabelEnable           = "docktail.service.enable"
 	LabelService          = "docktail.service.name"
+	LabelDescription      = "docktail.service.description"
 	LabelPort             = "docktail.service.service-port"
 	LabelServiceProtocol  = "docktail.service.service-protocol"
 	LabelTarget           = "docktail.service.port"


### PR DESCRIPTION
Closes #60.

## What

Adds a `docktail.service.description` label so a container can set the human-readable description shown per service in the Tailscale admin panel — the feature requested in #60:

```yaml
labels:
  - "docktail.service.enable=true"
  - "docktail.service.name=linkding"
  - "docktail.service.port=9090"
  - "docktail.service.description=Bookmark Manager"
```

Indexed services can carry their own description via `docktail.service.N.description`.

## How

The admin-panel description maps to the Service definition's `comment` field on the Tailscale Control Plane (confirmed against the Tailscale API `VIPServiceInfo` schema). DockTail syncs it there during reconciliation:

- **Create:** the `comment` is included when a new Service definition is created.
- **Update:** on an existing Service, the description is reconciled — if the label value differs from the current comment, the comment is updated (tags and ports are still left untouched to avoid clobbering manual changes). When no description label is set, existing comments are never touched.

Because the comment lives on the Control Plane definition (not in local `tailscale serve` config), this requires API credentials (OAuth or API key). Without them, the label is simply a no-op — same gating as the existing service-definition sync.

## Tests

- **Unit** (`tailscale/client_test.go`): `TestAggregateServiceDefinitions` covers the description carrying onto the aggregated definition, empty descriptions, first-non-empty-wins on port aggregation, and independent per-index descriptions.
- **E2E** (`e2e.sh` §14 + `docker-compose.e2e.yaml`): new `e2e-description` fixture with a primary and an indexed description. The test asserts the services exist locally and that each description is synced to the Control Plane `comment` via the API (`api_service_comment` helper). API assertions skip cleanly when no OAuth credentials are configured, matching the existing cleanup-test section.

## Docs

- `docs/04-labels.md`: new label row + added `description` to the per-index overridable labels.
- `docs/05-examples.md`: added a concise "Service With A Description" example.

(Generated website artifacts under `website/` are gitignored build outputs and are not committed; regenerate locally with `go run ./tools/docsgen` if needed.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for service descriptions in synced service definitions, including per-service and per-index values.
  * Added a new example and compose setup showing how to configure service descriptions.

* **Bug Fixes**
  * Existing services now update their description when it changes, instead of leaving stale text in place.
  * Improved handling of multiple services from one container so descriptions stay associated with the correct service.

* **Documentation**
  * Updated label reference docs to include the new description label and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->