### PR TITLE
feat: optionally keep services advertised on shutdown (#61)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,8 @@ DEFAULT_SERVICE_TAGS=tag:container
 # Disabled by default. Requires API credentials. Safe to run alongside other
 # DockTail instances: a Service advertised by any host is never deleted.
 # DELETE_UNUSED_SERVICES=false
+
+# Leave services and funnels advertised when DockTail shuts down (Optional)
+# Disabled by default (DockTail drains and clears them on shutdown). Set to true
+# to keep them reachable while DockTail is down. Only affects graceful shutdown.
+# SKIP_SHUTDOWN_CLEANUP=false

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ DEFAULT_SERVICE_TAGS=tag:container
 # DELETE_UNUSED_SERVICES=false
 
 # Leave services and funnels advertised when DockTail shuts down (Optional)
-# Disabled by default (DockTail drains and clears them on shutdown). Set to true
-# to keep them reachable while DockTail is down. Only affects graceful shutdown.
+# Disabled by default (DockTail drains and clears them on shutdown). Only affects
+# graceful shutdown. Caution: while DockTail is down this keeps ports exposed on
+# the tailnet, potentially beyond what your labels define -- a container you stop
+# or unlabel stays reachable until DockTail restarts and reconciles it away.
 # SKIP_SHUTDOWN_CLEANUP=false

--- a/docs/06-reference.md
+++ b/docs/06-reference.md
@@ -13,6 +13,7 @@ Use this section when checking exact configuration names, defaults, and supporte
 | `DEFAULT_SERVICE_TAGS` | `tag:container` | Default tags assigned to services. |
 | `IGNORE_SERVICE_NAMES` | - | Comma-separated service names DockTail must not drain, clear, or delete during reconciliation or shutdown cleanup. |
 | `DELETE_UNUSED_SERVICES` | `false` | When `true`, DockTail deletes tailnet Service definitions that no host advertises anymore. Requires API credentials. See [Cleanup Behavior](#cleanup-behavior). |
+| `SKIP_SHUTDOWN_CLEANUP` | `false` | When `true`, DockTail leaves its services and Funnels advertised on shutdown instead of draining and clearing them, so they stay reachable while DockTail is down. See [Cleanup Behavior](#cleanup-behavior). |
 | `LOG_LEVEL` | `info` | Logging level: `debug`, `info`, `warn`, or `error`. |
 | `RECONCILE_INTERVAL` | `60s` | State reconciliation interval. |
 | `DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon socket. |
@@ -66,7 +67,9 @@ Funnel `docktail.funnel.protocol` values:
 
 ### Cleanup Behavior
 
-DockTail cleans up the services it advertises locally when it shuts down.
+DockTail cleans up the services and Funnels it advertises locally when it shuts down (draining then clearing them).
+
+Set `SKIP_SHUTDOWN_CLEANUP=true` to skip this. DockTail then leaves its services and Funnels advertised when it exits, so they stay reachable while DockTail is down. This affects only graceful shutdown; a hard crash never runs cleanup either way. On restart, DockTail re-adopts the still-advertised services and removes only those whose containers are no longer running. Ignored services (`IGNORE_SERVICE_NAMES`) are unaffected because they are never cleaned up regardless of this setting.
 
 By default it does **not** delete Tailscale Service definitions from the Control Plane when containers stop; this is a conservative strategy that avoids removing definitions unexpectedly.
 

--- a/docs/06-reference.md
+++ b/docs/06-reference.md
@@ -13,7 +13,7 @@ Use this section when checking exact configuration names, defaults, and supporte
 | `DEFAULT_SERVICE_TAGS` | `tag:container` | Default tags assigned to services. |
 | `IGNORE_SERVICE_NAMES` | - | Comma-separated service names DockTail must not drain, clear, or delete during reconciliation or shutdown cleanup. |
 | `DELETE_UNUSED_SERVICES` | `false` | When `true`, DockTail deletes tailnet Service definitions that no host advertises anymore. Requires API credentials. See [Cleanup Behavior](#cleanup-behavior). |
-| `SKIP_SHUTDOWN_CLEANUP` | `false` | When `true`, DockTail leaves its services and Funnels advertised on shutdown instead of draining and clearing them, so they stay reachable while DockTail is down. See [Cleanup Behavior](#cleanup-behavior). |
+| `SKIP_SHUTDOWN_CLEANUP` | `false` | When `true`, DockTail leaves its services and Funnels advertised on shutdown instead of draining and clearing them. This can keep ports exposed on the tailnet beyond what your current labels define; see [Cleanup Behavior](#cleanup-behavior). |
 | `LOG_LEVEL` | `info` | Logging level: `debug`, `info`, `warn`, or `error`. |
 | `RECONCILE_INTERVAL` | `60s` | State reconciliation interval. |
 | `DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon socket. |
@@ -67,11 +67,15 @@ Funnel `docktail.funnel.protocol` values:
 
 ### Cleanup Behavior
 
-DockTail cleans up the services and Funnels it advertises locally when it shuts down (draining then clearing them).
+DockTail cleans up the services and Funnels it advertises locally when it shuts down (draining then clearing them). This is the safe default: when DockTail is not running, nothing it configured stays reachable, so the advertised surface can never drift from what your labels describe.
 
-Set `SKIP_SHUTDOWN_CLEANUP=true` to skip this. DockTail then leaves its services and Funnels advertised when it exits, so they stay reachable while DockTail is down. This affects only graceful shutdown; a hard crash never runs cleanup either way. On restart, DockTail re-adopts the still-advertised services and removes only those whose containers are no longer running. Ignored services (`IGNORE_SERVICE_NAMES`) are unaffected because they are never cleaned up regardless of this setting.
+`SKIP_SHUTDOWN_CLEANUP=true` disables this cleanup. DockTail then leaves its services and Funnels advertised when it exits instead of tearing them down. It affects only graceful shutdown; a hard crash never runs cleanup either way.
 
-By default it does **not** delete Tailscale Service definitions from the Control Plane when containers stop; this is a conservative strategy that avoids removing definitions unexpectedly.
+> **Warning:** Enabling this keeps ports exposed on the tailnet while DockTail is down, potentially beyond what your current labels define. The serve and Funnel configuration lives in `tailscaled`, not in DockTail, so anything DockTail last advertised keeps serving on the host until DockTail comes back. If you stop a container, remove it, or delete its DockTail labels while DockTail is not running, that service (and any Funnel) stays reachable for the entire downtime and is only reconciled away once DockTail restarts. The default cleanup exists precisely to prevent this stale exposure. Only enable `SKIP_SHUTDOWN_CLEANUP` if keeping services reachable across DockTail restarts is worth giving up that guarantee, and treat the advertised surface as detached from your labels until DockTail is running again.
+
+On restart, DockTail re-adopts the still-advertised services and removes only those whose containers are no longer running. Ignored services (`IGNORE_SERVICE_NAMES`) are never cleaned up regardless of this setting.
+
+By default DockTail does **not** delete Tailscale Service definitions from the Control Plane when containers stop; this is a conservative strategy that avoids removing definitions unexpectedly.
 
 #### Deleting unused Service definitions
 

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 	defaultTagsStr := getEnv("DEFAULT_SERVICE_TAGS", "tag:container")
 	ignoreServiceNamesStr := getEnv("IGNORE_SERVICE_NAMES", "")
 	deleteUnusedServices := getEnvBool("DELETE_UNUSED_SERVICES", false)
+	skipShutdownCleanup := getEnvBool("SKIP_SHUTDOWN_CLEANUP", false)
 
 	// Parse default tags
 	var defaultTags []string
@@ -80,6 +81,7 @@ func main() {
 		Strs("default_tags", defaultTags).
 		Strs("ignore_service_names", ignoreServiceNames).
 		Bool("delete_unused_services", deleteUnusedServices).
+		Bool("skip_shutdown_cleanup", skipShutdownCleanup).
 		Msg("Configuration loaded")
 
 	// Create Docker client
@@ -129,7 +131,16 @@ func main() {
 		log.Fatal().Err(err).Msg("Reconciler failed")
 	}
 
-	// Graceful shutdown: clean up all Tailscale services
+	// Graceful shutdown: optionally clean up all Tailscale services and funnels.
+	// When SKIP_SHUTDOWN_CLEANUP is enabled we leave everything advertised so the
+	// services stay reachable while DockTail is down. The serve/funnel config lives
+	// in tailscaled, not in DockTail, so skipping cleanup keeps it in place.
+	if skipShutdownCleanup {
+		log.Info().Msg("SKIP_SHUTDOWN_CLEANUP is enabled, leaving Tailscale services and funnels advertised")
+		log.Info().Msg("DockTail stopped gracefully")
+		return
+	}
+
 	log.Info().Msg("Reconciler stopped, cleaning up Tailscale services")
 
 	// Use a new context with timeout for cleanup (don't use cancelled context)


### PR DESCRIPTION
Closes #61.

## What

Adds a new opt-in env flag `SKIP_SHUTDOWN_CLEANUP` (default `false`). When enabled, DockTail leaves its services **and** Funnels advertised on shutdown instead of draining and clearing them, so they stay reachable while DockTail is down.

## Why

Today, when DockTail shuts down gracefully it always drains and clears everything it advertises, which takes the services offline. #61 asks for a way to keep them up when DockTail itself goes down (e.g. during a DockTail restart/upgrade) while the backing containers keep running.

## How

The serve/Funnel configuration lives in `tailscaled`, not in DockTail — so simply *not* running the shutdown cleanup keeps everything in place. The change gates the existing `CleanupAllServices` call in `main.go` behind the flag; the client code is untouched.

Scope notes:
- Only the **graceful** shutdown path is affected. A hard crash (SIGKILL/OOM) never ran cleanup anyway.
- Normal reconciliation is unchanged — when a *container* stops, its service is still drained/cleared. This flag only concerns DockTail itself going down.
- On restart, DockTail re-adopts the still-advertised services and removes only those whose containers are no longer running.
- Default is unchanged behavior (cleanup on shutdown).

## Docs

- `.env.example` — documented the new flag
- `docs/06-reference.md` — env-var table row + Cleanup Behavior section
- Generated website artifacts are gitignored build outputs; not committed.

## Config

| Variable | Default | Behavior |
| --- | --- | --- |
| `SKIP_SHUTDOWN_CLEANUP` | `false` | `true` leaves services and Funnels advertised on shutdown |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional shutdown setting to keep advertised services and funnels reachable when the app stops gracefully.
* **Documentation**
  * Updated setup docs and reference material with the new setting, its default value, and how it affects shutdown behavior.
* **Bug Fixes**
  * Improved shutdown behavior by allowing cleanup to be skipped when desired, while keeping the default cleanup flow unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->