### PR TITLE
feat: reconcile service tags authoritatively on every sync

### DIFF
--- a/docker/client.go
+++ b/docker/client.go
@@ -409,6 +409,40 @@ func (c *Client) parseFunnelConfig(cctx *containerCtx, labels map[string]string)
 
 // parseContainer extracts service configuration from container labels.
 // Returns one ContainerService for the primary port plus one for each indexed port.
+// parseTags parses a comma-separated docktail.tags label value into a
+// deduplicated tag list, falling back to a copy of defaultTags when the label
+// is empty. Duplicates must be dropped: the Control Plane stores tags as a
+// set, so a desired list with duplicates would register as permanent drift
+// and trigger a re-PUT on every reconcile cycle.
+func parseTags(tagsStr string, containerName string, defaultTags []string) []string {
+	if tagsStr == "" {
+		tags := make([]string, len(defaultTags))
+		copy(tags, defaultTags)
+		return tags
+	}
+
+	var tags []string
+	seen := make(map[string]struct{})
+	for _, part := range strings.Split(tagsStr, ",") {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		if _, dup := seen[trimmed]; dup {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		if !strings.HasPrefix(trimmed, "tag:") {
+			log.Warn().
+				Str("container", containerName).
+				Str("tag", trimmed).
+				Msg("Tag should start with 'tag:' prefix per Tailscale convention")
+		}
+		tags = append(tags, trimmed)
+	}
+	return tags
+}
+
 func (c *Client) parseContainer(ctx context.Context, containerID string, labels map[string]string) ([]*apptypes.ContainerService, error) {
 	serviceEnabled := isServiceEnabled(labels)
 	funnelEnabled := isFunnelEnabled(labels)
@@ -434,26 +468,7 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 		isDirectMode:     labels[apptypes.LabelDirect] != "false",
 	}
 
-	// Parse tags
-	var tags []string
-	if tagsStr := labels[apptypes.LabelTags]; tagsStr != "" {
-		parts := strings.Split(tagsStr, ",")
-		for _, part := range parts {
-			if trimmed := strings.TrimSpace(part); trimmed != "" {
-				if !strings.HasPrefix(trimmed, "tag:") {
-					log.Warn().
-						Str("container", cctx.containerName).
-						Str("tag", trimmed).
-						Msg("Tag should start with 'tag:' prefix per Tailscale convention")
-				}
-				tags = append(tags, trimmed)
-			}
-		}
-	} else {
-		tags = make([]string, len(c.defaultTags))
-		copy(tags, c.defaultTags)
-	}
-	cctx.tags = tags
+	cctx.tags = parseTags(labels[apptypes.LabelTags], cctx.containerName, c.defaultTags)
 
 	var result []*apptypes.ContainerService
 	if serviceEnabled {
@@ -496,7 +511,7 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 			TargetPort:         destPort,
 			ServiceProtocol:    serviceProtocol,
 			Protocol:           protocol,
-			Tags:               tags,
+			Tags:               cctx.tags,
 			IPAddress:          destIP,
 		}
 		result = append(result, primary)
@@ -531,7 +546,7 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 		ContainerID:      cctx.containerID[:12],
 		ContainerName:    cctx.containerName,
 		ServiceEnabled:   false,
-		Tags:             tags,
+		Tags:             cctx.tags,
 		IPAddress:        funnelCfg.IPAddress,
 		FunnelEnabled:    true,
 		FunnelPort:       funnelCfg.Port,

--- a/docker/client_test.go
+++ b/docker/client_test.go
@@ -1,11 +1,60 @@
 package docker
 
 import (
+	"slices"
 	"strconv"
 	"testing"
 
 	apptypes "github.com/marvinvr/docktail/types"
 )
+
+func TestParseTags(t *testing.T) {
+	defaultTags := []string{"tag:container"}
+
+	tests := []struct {
+		name    string
+		tagsStr string
+		want    []string
+	}{
+		{
+			name:    "splits and trims comma-separated tags",
+			tagsStr: " tag:web , tag:production ",
+			want:    []string{"tag:web", "tag:production"},
+		},
+		{
+			name:    "drops duplicates keeping first occurrence order",
+			tagsStr: "tag:web,tag:production,tag:web",
+			want:    []string{"tag:web", "tag:production"},
+		},
+		{
+			name:    "skips empty entries",
+			tagsStr: "tag:web,,tag:production,",
+			want:    []string{"tag:web", "tag:production"},
+		},
+		{
+			name:    "empty label falls back to default tags",
+			tagsStr: "",
+			want:    []string{"tag:container"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTags(tt.tagsStr, "test-container", defaultTags)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("parseTags(%q) = %v, want %v", tt.tagsStr, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("fallback returns a copy of the defaults", func(t *testing.T) {
+		got := parseTags("", "test-container", defaultTags)
+		got[0] = "tag:mutated"
+		if defaultTags[0] != "tag:container" {
+			t.Errorf("mutating the result changed defaultTags to %v", defaultTags)
+		}
+	})
+}
 
 func TestResolveProtocols(t *testing.T) {
 	tests := []struct {

--- a/docs/04-labels.md
+++ b/docs/04-labels.md
@@ -31,7 +31,9 @@ Set `docktail.service.direct=false` to use published host ports instead. This is
 | `docktail.service.protocol` | No | Smart | Backend protocol. |
 | `docktail.service.service-port` | No | Smart | Port Tailscale listens on. |
 | `docktail.service.service-protocol` | No | Smart | Tailscale-facing protocol. |
-| `docktail.tags` | No | `tag:container` | Comma-separated service tags. |
+| `docktail.tags` | No | `tag:container` | Comma-separated service tags. Labels are the source of truth; see the note below. |
+
+Tags are synced to the tailnet Service definition through the Tailscale API and require API credentials. Labels are authoritative: DockTail reconciles tags on every cycle, so tags edited by hand in the Tailscale admin console are reverted to the label-declared set on the next reconcile. Containers without a `docktail.tags` label use `DEFAULT_SERVICE_TAGS`.
 
 Smart defaults:
 

--- a/docs/06-reference.md
+++ b/docs/06-reference.md
@@ -10,7 +10,7 @@ Use this section when checking exact configuration names, defaults, and supporte
 | `TAILSCALE_OAUTH_CLIENT_SECRET` | - | OAuth client secret. Enables automatic service creation when paired with the client ID. |
 | `TAILSCALE_API_KEY` | - | API key alternative to OAuth. |
 | `TAILSCALE_TAILNET` | `-` | Tailnet ID. Defaults to the credential's tailnet. |
-| `DEFAULT_SERVICE_TAGS` | `tag:container` | Default tags assigned to services. |
+| `DEFAULT_SERVICE_TAGS` | `tag:container` | Default tags for services whose containers set no `docktail.tags` label. Tags are reconciled on every cycle; manual tag edits in the admin console are overwritten. |
 | `IGNORE_SERVICE_NAMES` | - | Comma-separated service names DockTail must not drain, clear, or delete during reconciliation or shutdown cleanup. |
 | `DELETE_UNUSED_SERVICES` | `false` | When `true`, DockTail deletes tailnet Service definitions that no host advertises anymore. Requires API credentials. See [Cleanup Behavior](#cleanup-behavior). |
 | `SKIP_SHUTDOWN_CLEANUP` | `false` | When `true`, DockTail leaves its services and Funnels advertised on shutdown instead of draining and clearing them. This can keep ports exposed on the tailnet beyond what your current labels define; see [Cleanup Behavior](#cleanup-behavior). |

--- a/docs/07-how-it-works.md
+++ b/docs/07-how-it-works.md
@@ -28,7 +28,7 @@ Tailnet clients access container services
 3. It resolves the backend destination from Docker network settings or published ports.
 4. It generates Tailscale service configuration pointing to that backend.
 5. It executes the Tailscale CLI to advertise services and Funnels.
-6. If OAuth or API key credentials are configured, it creates service definitions through the Tailscale API.
+6. If OAuth or API key credentials are configured, it creates service definitions through the Tailscale API and keeps their tags and descriptions in sync with the labels; manual edits to either are overwritten.
 7. If `DELETE_UNUSED_SERVICES` is enabled, it deletes tailnet service definitions that no host advertises anymore.
 8. It periodically reconciles state so container IP changes are handled automatically.
 

--- a/e2e.sh
+++ b/e2e.sh
@@ -356,6 +356,29 @@ assert_service_tags() {
     fi
 }
 
+# Simulate a manual admin-console edit on an existing service definition:
+# fetch the current definition, overwrite its tags and comment, and PUT it
+# back with name/addrs/ports preserved. Echoes the PUT HTTP status code.
+# Usage: api_tamper_service_tags <token> <svc:name> <comment> <tag>...
+api_tamper_service_tags() {
+    local token="$1" name="$2" comment="$3"
+    shift 3
+    local current payload
+    current=$(curl -s -H "Authorization: Bearer ${token}" \
+        "${API_BASE}/tailnet/${API_TAILNET}/services/${name}" 2>/dev/null)
+    payload=$(echo "$current" | jq -c --arg comment "$comment" --args \
+        '.tags = $ARGS.positional | .comment = $comment' "$@" 2>/dev/null)
+    if [ -z "$payload" ]; then
+        echo "000"
+        return
+    fi
+    curl -s -o /dev/null -w "%{http_code}" -X PUT \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/json" \
+        -d "$payload" \
+        "${API_BASE}/tailnet/${API_TAILNET}/services/${name}" 2>/dev/null || echo "000"
+}
+
 # Delete a service definition (best effort).
 api_delete_service() {
     local token="$1" name="$2"
@@ -898,10 +921,53 @@ else
 fi
 
 # ==============================================================================
-# 15. Log Health
+# 15. Authoritative Tag Reconciliation (issue #63)
+# ==============================================================================
+#
+# https://github.com/marvinvr/docktail/issues/63
+# Labels are the source of truth for service tags: manual edits to a service
+# definition's tags in the admin console must be overwritten on the next
+# reconcile. Previously tags were only applied at creation time, so a tag label
+# added after the service already existed never took effect.
+#
+# Simulate a manual console edit by rewriting svc:e2e-custom-tags with a stale
+# tag set plus a manual comment, then assert DockTail converges the tags back
+# to the label-declared set. The container declares no description label, so
+# the manual comment must survive the tag update (an empty declared value
+# means DockTail leaves the existing one alone).
+
+log "15. Authoritative Tag Reconciliation (issue #63)"
+
+TAG_SYNC_TOKEN=$(mint_api_token)
+if [ -z "$TAG_SYNC_TOKEN" ]; then
+    fail "no OAuth credentials available to verify tag reconciliation via Control Plane API"
+else
+    echo "  --- Simulating a manual tag edit in the admin console ---"
+    tamper_status=$(api_tamper_service_tags "$TAG_SYNC_TOKEN" "svc:e2e-custom-tags" "e2e manual comment" "tag:ci-test-container")
+    if [ "$tamper_status" = "200" ]; then
+        pass "rewrote svc:e2e-custom-tags with stale tags via API"
+    else
+        fail "failed to rewrite svc:e2e-custom-tags via API (status $tamper_status)"
+    fi
+
+    echo "  --- DockTail must revert the tags to the label-declared set ---"
+    assert_service_tags "$TAG_SYNC_TOKEN" "e2e-custom-tags" "tag:web" "tag:production"
+    wait_for_docktail_log "Updating service tags in Control Plane"
+
+    echo "  --- Manual comment survives (no description label declared) ---"
+    tampered_comment=$(api_service_comment "$TAG_SYNC_TOKEN" "svc:e2e-custom-tags")
+    if [ "$tampered_comment" = "e2e manual comment" ]; then
+        pass "manual comment preserved on svc:e2e-custom-tags"
+    else
+        fail "manual comment lost on svc:e2e-custom-tags (got '${tampered_comment:-<none>}')"
+    fi
+fi
+
+# ==============================================================================
+# 16. Log Health
 # ==============================================================================
 
-log "15. DockTail Log Health"
+log "16. DockTail Log Health"
 docktail_logs=$(docker logs "$DOCKTAIL_CONTAINER" 2>&1)
 
 if grep -qE "FATAL|panic" <<<"$docktail_logs"; then

--- a/main.go
+++ b/main.go
@@ -39,12 +39,21 @@ func main() {
 	deleteUnusedServices := getEnvBool("DELETE_UNUSED_SERVICES", false)
 	skipShutdownCleanup := getEnvBool("SKIP_SHUTDOWN_CLEANUP", false)
 
-	// Parse default tags
+	// Parse default tags, dropping duplicates: the Control Plane stores tags
+	// as a set, so a duplicated default would register as permanent drift and
+	// trigger a re-PUT on every reconcile cycle.
 	var defaultTags []string
+	seenDefaultTags := make(map[string]struct{})
 	for _, tag := range strings.Split(defaultTagsStr, ",") {
-		if trimmed := strings.TrimSpace(tag); trimmed != "" {
-			defaultTags = append(defaultTags, trimmed)
+		trimmed := strings.TrimSpace(tag)
+		if trimmed == "" {
+			continue
 		}
+		if _, dup := seenDefaultTags[trimmed]; dup {
+			continue
+		}
+		seenDefaultTags[trimmed] = struct{}{}
+		defaultTags = append(defaultTags, trimmed)
 	}
 
 	// Parse ignored service names

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"slices"
 	"strings"
 	"time"
 
@@ -499,13 +498,27 @@ func (c *Client) SyncServiceDefinition(ctx context.Context, serviceName string, 
 	return nil
 }
 
-// sameStringSet reports whether a and b contain the same elements, ignoring
-// order.
+// sameStringSet reports whether a and b contain the same unique elements,
+// ignoring order and duplicates. Duplicates must not count as difference: the
+// Control Plane stores tags as a set, so treating a duplicated desired list
+// as drift would trigger a re-PUT on every reconcile cycle.
 func sameStringSet(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
+	setA := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		setA[s] = struct{}{}
 	}
-	return slices.Equal(slices.Sorted(slices.Values(a)), slices.Sorted(slices.Values(b)))
+	distinctB := 0
+	seenB := make(map[string]struct{}, len(b))
+	for _, s := range b {
+		if _, ok := setA[s]; !ok {
+			return false
+		}
+		if _, dup := seenB[s]; !dup {
+			seenB[s] = struct{}{}
+			distinctB++
+		}
+	}
+	return len(setA) == distinctB
 }
 
 // putService PUTs a service definition payload to the Control Plane API.

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -396,11 +397,16 @@ func (c *Client) syncServiceDefinitions(ctx context.Context, services []*apptype
 	return nil
 }
 
-// SyncServiceDefinition ensures a service definition exists in the Tailscale API.
-// It creates the service (with an optional description) if it doesn't exist. For
-// an already-existing service it does NOT touch tags or ports, but it does
-// reconcile the description (the admin-panel "comment") when a description label
-// is set and differs from the current value.
+// SyncServiceDefinition ensures a service definition exists in the Tailscale API
+// and matches the label-declared state. It creates the service (with an optional
+// description) if it doesn't exist. For an already-existing service it
+// reconciles tags and the description (the admin-panel "comment"): labels are
+// the source of truth, so manual edits to either are overwritten on the next
+// run (issue #63). An empty desired tag set or description means "nothing
+// declared" and leaves the existing value alone. Ports and addrs are never
+// touched on existing services: the definition is tailnet-global and other
+// hosts may back the same service, so no single instance knows the full
+// desired port set.
 func (c *Client) SyncServiceDefinition(ctx context.Context, serviceName string, tags []string, ports []string, description string) error {
 	if !strings.HasPrefix(serviceName, "svc:") {
 		serviceName = "svc:" + serviceName
@@ -412,29 +418,44 @@ func (c *Client) SyncServiceDefinition(ctx context.Context, serviceName string, 
 		return fmt.Errorf("failed to get service details: %w", err)
 	}
 
-	// If service already exists, only reconcile the description. Tags and ports
-	// are intentionally left untouched to avoid clobbering manual changes.
 	if existing != nil {
-		if description == "" || existing.Comment == description {
+		tagsDrifted := len(tags) > 0 && !sameStringSet(existing.Tags, tags)
+		descriptionDrifted := description != "" && existing.Comment != description
+
+		if !tagsDrifted && !descriptionDrifted {
 			log.Debug().
 				Str("service", serviceName).
 				Strs("existing_tags", existing.Tags).
 				Strs("existing_ports", existing.Ports).
-				Msg("Service already exists in Control Plane, skipping creation")
+				Msg("Service definition already up to date in Control Plane")
 			return nil
 		}
 
-		log.Info().
-			Str("service", serviceName).
-			Str("description", description).
-			Msg("Updating service description in Control Plane")
+		desiredTags := existing.Tags
+		if tagsDrifted {
+			desiredTags = tags
+			log.Info().
+				Str("service", serviceName).
+				Strs("old_tags", existing.Tags).
+				Strs("new_tags", tags).
+				Msg("Updating service tags in Control Plane")
+		}
+
+		comment := existing.Comment
+		if descriptionDrifted {
+			comment = description
+			log.Info().
+				Str("service", serviceName).
+				Str("description", description).
+				Msg("Updating service description in Control Plane")
+		}
 
 		payload := map[string]interface{}{
 			"name":    serviceName,
 			"addrs":   existing.Addrs,
-			"tags":    existing.Tags,
+			"tags":    desiredTags,
 			"ports":   existing.Ports,
-			"comment": description,
+			"comment": comment,
 		}
 		return c.putService(ctx, serviceName, payload)
 	}
@@ -476,6 +497,15 @@ func (c *Client) SyncServiceDefinition(ctx context.Context, serviceName string, 
 		Msg("Successfully created service definition in Control Plane")
 
 	return nil
+}
+
+// sameStringSet reports whether a and b contain the same elements, ignoring
+// order.
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return slices.Equal(slices.Sorted(slices.Values(a)), slices.Sorted(slices.Values(b)))
 }
 
 // putService PUTs a service definition payload to the Control Plane API.

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -1,6 +1,11 @@
 package tailscale
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
 	"testing"
 
 	apptypes "github.com/marvinvr/docktail/types"
@@ -86,6 +91,189 @@ func TestAggregateServiceDefinitions(t *testing.T) {
 						}
 					}
 				}
+			}
+		})
+	}
+}
+
+// servicePutPayload mirrors the JSON body SyncServiceDefinition PUTs to the
+// Control Plane API.
+type servicePutPayload struct {
+	Name    string   `json:"name"`
+	Addrs   []string `json:"addrs"`
+	Tags    []string `json:"tags"`
+	Ports   []string `json:"ports"`
+	Comment string   `json:"comment"`
+}
+
+func TestSyncServiceDefinitionReconciliation(t *testing.T) {
+	tests := []struct {
+		name        string
+		existing    *apiService // nil = service does not exist (GET returns 404)
+		tags        []string
+		ports       []string
+		description string
+		wantPut     bool
+		want        servicePutPayload
+	}{
+		{
+			name: "tag drift is reconciled, ports addrs and manual comment preserved",
+			existing: &apiService{
+				Name:    "svc:web",
+				Addrs:   []string{"100.100.1.1"},
+				Tags:    []string{"tag:container"},
+				Ports:   []string{"tcp:443"},
+				Comment: "manual note",
+			},
+			tags:    []string{"tag:web", "tag:production"},
+			ports:   []string{"443", "8080"},
+			wantPut: true,
+			want: servicePutPayload{
+				Name:    "svc:web",
+				Addrs:   []string{"100.100.1.1"},
+				Tags:    []string{"tag:web", "tag:production"},
+				Ports:   []string{"tcp:443"},
+				Comment: "manual note",
+			},
+		},
+		{
+			name: "identical tags in different order are not drift",
+			existing: &apiService{
+				Name: "svc:web",
+				Tags: []string{"tag:b", "tag:a"},
+			},
+			tags:    []string{"tag:a", "tag:b"},
+			wantPut: false,
+		},
+		{
+			name: "empty desired tags leave existing tags alone",
+			existing: &apiService{
+				Name: "svc:web",
+				Tags: []string{"tag:manual"},
+			},
+			tags:    nil,
+			wantPut: false,
+		},
+		{
+			name: "tag and description drift update together",
+			existing: &apiService{
+				Name:    "svc:web",
+				Tags:    []string{"tag:container"},
+				Ports:   []string{"tcp:80"},
+				Comment: "old",
+			},
+			tags:        []string{"tag:web"},
+			description: "new",
+			wantPut:     true,
+			want: servicePutPayload{
+				Name:    "svc:web",
+				Tags:    []string{"tag:web"},
+				Ports:   []string{"tcp:80"},
+				Comment: "new",
+			},
+		},
+		{
+			name: "description drift alone keeps existing tags",
+			existing: &apiService{
+				Name:  "svc:web",
+				Tags:  []string{"tag:manual", "tag:extra"},
+				Ports: []string{"tcp:80"},
+			},
+			tags:        []string{"tag:manual", "tag:extra"},
+			description: "described",
+			wantPut:     true,
+			want: servicePutPayload{
+				Name:    "svc:web",
+				Tags:    []string{"tag:manual", "tag:extra"},
+				Ports:   []string{"tcp:80"},
+				Comment: "described",
+			},
+		},
+		{
+			name: "fully converged service is not rewritten",
+			existing: &apiService{
+				Name:    "svc:web",
+				Tags:    []string{"tag:web"},
+				Comment: "same",
+			},
+			tags:        []string{"tag:web"},
+			description: "same",
+			wantPut:     false,
+		},
+		{
+			name:        "missing service is created with tcp-prefixed ports",
+			existing:    nil,
+			tags:        []string{"tag:web"},
+			ports:       []string{"443", "8080"},
+			description: "hello",
+			wantPut:     true,
+			want: servicePutPayload{
+				Name:    "svc:web",
+				Tags:    []string{"tag:web"},
+				Ports:   []string{"tcp:443", "tcp:8080"},
+				Comment: "hello",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPut *servicePutPayload
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					if tt.existing == nil {
+						w.WriteHeader(http.StatusNotFound)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(tt.existing)
+				case http.MethodPut:
+					var payload servicePutPayload
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						t.Errorf("failed to decode PUT payload: %v", err)
+					}
+					gotPut = &payload
+					w.WriteHeader(http.StatusOK)
+				default:
+					t.Errorf("unexpected %s request", r.Method)
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			}))
+			defer srv.Close()
+
+			c := &Client{
+				baseURL:    srv.URL,
+				tailnet:    "example.com",
+				httpClient: srv.Client(),
+			}
+
+			if err := c.SyncServiceDefinition(context.Background(), "web", tt.tags, tt.ports, tt.description); err != nil {
+				t.Fatalf("SyncServiceDefinition returned error: %v", err)
+			}
+
+			if !tt.wantPut {
+				if gotPut != nil {
+					t.Fatalf("unexpected PUT with payload %+v", *gotPut)
+				}
+				return
+			}
+			if gotPut == nil {
+				t.Fatal("expected a PUT to the Control Plane, got none")
+			}
+			if gotPut.Name != tt.want.Name {
+				t.Errorf("name = %q, want %q", gotPut.Name, tt.want.Name)
+			}
+			if !slices.Equal(gotPut.Addrs, tt.want.Addrs) {
+				t.Errorf("addrs = %v, want %v", gotPut.Addrs, tt.want.Addrs)
+			}
+			if !slices.Equal(gotPut.Tags, tt.want.Tags) {
+				t.Errorf("tags = %v, want %v", gotPut.Tags, tt.want.Tags)
+			}
+			if !slices.Equal(gotPut.Ports, tt.want.Ports) {
+				t.Errorf("ports = %v, want %v", gotPut.Ports, tt.want.Ports)
+			}
+			if gotPut.Comment != tt.want.Comment {
+				t.Errorf("comment = %q, want %q", gotPut.Comment, tt.want.Comment)
 			}
 		})
 	}

--- a/tailscale/client_test.go
+++ b/tailscale/client_test.go
@@ -96,6 +96,33 @@ func TestAggregateServiceDefinitions(t *testing.T) {
 	}
 }
 
+func TestSameStringSet(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want bool
+	}{
+		{name: "equal ignoring order", a: []string{"tag:a", "tag:b"}, b: []string{"tag:b", "tag:a"}, want: true},
+		{name: "duplicates do not count as difference", a: []string{"tag:a", "tag:a", "tag:b"}, b: []string{"tag:b", "tag:a"}, want: true},
+		{name: "missing element", a: []string{"tag:a"}, b: []string{"tag:a", "tag:b"}, want: false},
+		{name: "duplicates cannot mask a missing element", a: []string{"tag:a", "tag:b"}, b: []string{"tag:b", "tag:b"}, want: false},
+		{name: "extra element", a: []string{"tag:a", "tag:b"}, b: []string{"tag:a"}, want: false},
+		{name: "both empty", a: nil, b: []string{}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameStringSet(tt.a, tt.b); got != tt.want {
+				t.Errorf("sameStringSet(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+			if got := sameStringSet(tt.b, tt.a); got != tt.want {
+				t.Errorf("sameStringSet(%v, %v) = %v, want %v", tt.b, tt.a, got, tt.want)
+			}
+		})
+	}
+}
+
 // servicePutPayload mirrors the JSON body SyncServiceDefinition PUTs to the
 // Control Plane API.
 type servicePutPayload struct {
@@ -152,6 +179,15 @@ func TestSyncServiceDefinitionReconciliation(t *testing.T) {
 				Tags: []string{"tag:manual"},
 			},
 			tags:    nil,
+			wantPut: false,
+		},
+		{
+			name: "duplicate desired tags are not drift against the deduped stored set",
+			existing: &apiService{
+				Name: "svc:web",
+				Tags: []string{"tag:web"},
+			},
+			tags:    []string{"tag:web", "tag:web"},
 			wantPut: false,
 		},
 		{


### PR DESCRIPTION
Closes #63

## What changed

Tags declared via `docktail.tags` (or `DEFAULT_SERVICE_TAGS`) are now authoritative. `SyncServiceDefinition` reconciles tag drift on existing Service definitions on every cycle instead of only applying tags at creation time, so tags edited by hand in the Tailscale admin console are reverted to the label-declared set on the next reconcile.

Details:

- Tag comparison is order-independent; a drifted tag set (or a drifted description, as before) triggers a single `PUT` that preserves the existing `addrs` and `ports`.
- An empty desired tag set means "nothing declared" and leaves the existing tags alone (mirrors how an empty description is treated).
- When only tags drift and no description label is set, the existing comment is preserved instead of being blanked.
- Ports and addrs remain untouched on existing services: the definition is tailnet-global and other hosts/instances may back the same service, so no single DockTail instance knows the full desired port set.

## Tests

- Unit: `TestSyncServiceDefinitionReconciliation` covers tag drift (with comment preservation), order-independent comparison, the empty-tags guard, combined tag+description drift, description-only drift, the no-op path, and the create path.
- e2e: new section 15 simulates a manual admin-console edit by rewriting `svc:e2e-custom-tags` with a stale tag set plus a manual comment via the Control Plane API, then asserts DockTail converges the tags back to the label-declared set, logs the tag update, and preserves the manual comment.

## Docs

Updated `docs/04-labels.md`, `docs/06-reference.md`, and `docs/07-how-it-works.md`; regenerated website artifacts locally via `go run ./tools/docsgen` (gitignored).

Note for release notes: this is a behavior change — manually edited tags on DockTail-managed services will be reverted (to `tag:container` by default) within one reconcile interval after upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service tags and descriptions are synchronized from Docker labels during reconciliation.
  * Tag updates now account for tags differing only by ordering.
  * When no description label is set, manual service comments are preserved while tags are corrected.

* **Bug Fixes**
  * Drift handling restores stale tags and description changes automatically on the next reconcile.

* **Documentation**
  * Expanded service label and reconciliation documentation to clarify authoritative behavior and default tag handling.

* **Tests**
  * Added E2E and unit coverage for authoritative tag reconciliation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->