### PR TITLE
Revise OAuth credentials section in admin guide

### DIFF
--- a/docs/03-tailscale-admin.md
+++ b/docs/03-tailscale-admin.md
@@ -6,12 +6,12 @@ DockTail can advertise services locally without Tailscale API credentials, but O
 
 OAuth is recommended. It enables automatic service creation and avoids expiring API keys.
 
-1. Open Tailscale Admin Console -> Settings -> OAuth clients.
+1. Open Tailscale Admin Console -> Settings -> Trust credentials.
 2. Create an OAuth client scoped to your server tag, for example `tag:server`.
 3. Grant these permissions:
-   - General -> Services: Write
+   - General -> Services: Write (and specify required tag)
    - Devices -> Core: Write
-   - Keys -> Auth Keys: Write, only when using the sidecar method
+   - Keys -> Auth Keys: Write (only when using the sidecar method)
 
    These same permissions also cover the optional `DELETE_UNUSED_SERVICES` cleanup, which lists Services, inspects their advertising hosts, and deletes the ones no host advertises. No extra scope is required.
 4. Add the credentials to DockTail:


### PR DESCRIPTION
Cool new project! 

Updated OAuth client instructions and permissions for clarity and recent Tailscale UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated OAuth credential setup instructions to use **Settings → Trust credentials**.
  - Clarified how to scope OAuth clients to server tags and grant required permissions.
  - Added conditional guidance for **Auth Keys: Write** when using the sidecar method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->