### PR TITLE
Fix TLS termination for private TCP services

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -92,6 +92,19 @@ services:
       - "docktail.service.service-port=5432"
       - "docktail.service.service-protocol=tcp"
 
+  # TLS-terminated TCP service protocol
+  test-proto-tls-terminated-tcp:
+    image: nginx:alpine
+    container_name: e2e-proto-tls-terminated-tcp
+    restart: "no"
+    labels:
+      - "docktail.service.enable=true"
+      - "docktail.service.name=e2e-proto-tls-terminated-tcp"
+      - "docktail.service.port=80"
+      - "docktail.service.protocol=tcp"
+      - "docktail.service.service-port=6697"
+      - "docktail.service.service-protocol=tls-terminated-tcp"
+
   # ============================================================================
   # 2. Smart Defaults
   # ============================================================================

--- a/docs/07-reference.md
+++ b/docs/07-reference.md
@@ -57,7 +57,7 @@ Tailscale-facing `docktail.service.service-protocol` values:
 | `http` | Layer 7 HTTP. |
 | `https` | Layer 7 HTTPS with automatic TLS. |
 | `tcp` | Layer 4 TCP. |
-| `tls-terminated-tcp` | Layer 4 TCP with TLS termination. |
+| `tls-terminated-tcp` | Layer 4 TCP; Tailscale terminates incoming TLS and forwards decrypted TCP to the backend. |
 
 Container-facing `docktail.service.protocol` values:
 

--- a/e2e.sh
+++ b/e2e.sh
@@ -115,15 +115,18 @@ wait_for_service_state() {
     local expected_proto="$3"
     local timeout="${4:-30}"
     local elapsed=0
-    local actual_port is_https is_http actual_proto
+    local actual_port terminate_tls is_https is_http actual_proto
 
     while [ "$elapsed" -lt "$timeout" ]; do
         refresh_serve_status
         actual_port=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP | keys[0] // empty" 2>/dev/null || true)
         if [ "$actual_port" = "$expected_port" ]; then
+            terminate_tls=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP[\"$actual_port\"].TerminateTLS // empty" 2>/dev/null || true)
             is_https=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP[\"$actual_port\"].HTTPS // false" 2>/dev/null || true)
             is_http=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP[\"$actual_port\"].HTTP // false" 2>/dev/null || true)
-            if [ "$is_https" = "true" ]; then
+            if [ -n "$terminate_tls" ]; then
+                actual_proto="tls-terminated-tcp"
+            elif [ "$is_https" = "true" ]; then
                 actual_proto="https"
             elif [ "$is_http" = "true" ]; then
                 actual_proto="http"
@@ -205,7 +208,8 @@ assert_service_port_count() {
 }
 
 # Check service protocol via TCP config flags
-# "http" = HTTP:true, "https" = HTTPS:true, "tcp" = neither
+# "tls-terminated-tcp" = TerminateTLS set, "http" = HTTP:true,
+# "https" = HTTPS:true, "tcp" = none of those fields set.
 assert_service_protocol() {
     local name="svc:$1"
     local expected_proto="$2"
@@ -216,11 +220,14 @@ assert_service_protocol() {
         return
     fi
 
-    local is_https is_http actual
+    local terminate_tls is_https is_http actual
+    terminate_tls=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP[\"$port\"].TerminateTLS // empty" 2>/dev/null || true)
     is_https=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP[\"$port\"].HTTPS // false" 2>/dev/null || true)
     is_http=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP[\"$port\"].HTTP // false" 2>/dev/null || true)
 
-    if [ "$is_https" = "true" ]; then
+    if [ -n "$terminate_tls" ]; then
+        actual="tls-terminated-tcp"
+    elif [ "$is_https" = "true" ]; then
         actual="https"
     elif [ "$is_http" = "true" ]; then
         actual="http"
@@ -493,6 +500,11 @@ assert_service_exists       "e2e-proto-tcp"
 assert_service_port         "e2e-proto-tcp" "5432"
 assert_service_protocol     "e2e-proto-tcp" "tcp"
 
+echo "  --- TLS-terminated TCP ---"
+assert_service_exists       "e2e-proto-tls-terminated-tcp"
+assert_service_port         "e2e-proto-tls-terminated-tcp" "6697"
+assert_service_protocol     "e2e-proto-tls-terminated-tcp" "tls-terminated-tcp"
+
 # ==============================================================================
 # 2. Smart Defaults
 # ==============================================================================
@@ -702,6 +714,7 @@ refresh_serve_status
 assert_service_exists       "e2e-proto-http"
 assert_service_exists       "e2e-proto-https"
 assert_service_exists       "e2e-proto-tcp"
+assert_service_exists       "e2e-proto-tls-terminated-tcp"
 assert_service_exists       "e2e-default-minimal"
 assert_service_exists       "e2e-net-custom"
 assert_service_exists       "e2e-multiport"
@@ -715,11 +728,10 @@ assert_service_not_exists   "e2e-manual-protected"  # cleaned up explicitly
 # ==============================================================================
 #
 # Regression test for https://github.com/marvinvr/docktail/issues/56:
-# TCP services were detected as "changed" on every reconciliation cycle because
-# the current destination could not be parsed from the Tailscale serve status
-# (the TCP forward target lives on the TCP handler, not in the Web section).
-# This caused DockTail to re-add the TCP service on every reconciliation cycle,
-# even though the live configuration already matched the desired state.
+# TCP services were detected as "changed" on every reconciliation cycle when
+# DockTail could not parse their full Tailscale serve status. Plain TCP stores
+# its destination on the TCP handler (issue #56), while TLS-terminated TCP also
+# uses the TerminateTLS field to distinguish it from plain TCP (issue #71).
 #
 # A correctly reconciling TCP service is flagged as "changed" zero times once it
 # has been established. We measure the number of "Service configuration changed"
@@ -728,29 +740,39 @@ assert_service_not_exists   "e2e-manual-protected"  # cleaned up explicitly
 
 log "12. TCP Reconciliation Stability (issue #56)"
 
-tcp_changed_key="key=svc:e2e-proto-tcp:5432"
-
-count_tcp_changed() {
+count_service_changed() {
+    local changed_key="$1"
     docker logs "$DOCKTAIL_CONTAINER" 2>&1 \
         | grep "Service configuration changed, will update" \
-        | grep -c -- "$tcp_changed_key" || true
+        | grep -c -- "$changed_key" || true
 }
 
 echo "  --- Pre-check: TCP service exists ---"
 refresh_serve_status
 assert_service_exists       "e2e-proto-tcp"
 assert_service_protocol     "e2e-proto-tcp" "tcp"
+assert_service_exists       "e2e-proto-tls-terminated-tcp"
+assert_service_protocol     "e2e-proto-tls-terminated-tcp" "tls-terminated-tcp"
 
 echo "  Measuring TCP reconciliation stability across multiple cycles..."
-before_changed=$(count_tcp_changed)
+before_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tcp:5432")
+before_tls_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tls-terminated-tcp:6697")
 sleep 16   # >= 3 reconcile cycles at RECONCILE_INTERVAL=5s
-after_changed=$(count_tcp_changed)
-changed_delta=$((after_changed - before_changed))
+after_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tcp:5432")
+after_tls_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tls-terminated-tcp:6697")
+tcp_changed_delta=$((after_tcp_changed - before_tcp_changed))
+tls_tcp_changed_delta=$((after_tls_tcp_changed - before_tls_tcp_changed))
 
-if [ "$changed_delta" -le 0 ]; then
-    pass "TCP service stable: not re-detected as changed across cycles (delta=$changed_delta)"
+if [ "$tcp_changed_delta" -le 0 ]; then
+    pass "TCP service stable: not re-detected as changed across cycles (delta=$tcp_changed_delta)"
 else
-    fail "TCP service re-detected as changed $changed_delta time(s) across reconcile cycles (issue #56: TCP services re-added every reconciliation)"
+    fail "TCP service re-detected as changed $tcp_changed_delta time(s) across reconcile cycles (issue #56: TCP services re-added every reconciliation)"
+fi
+
+if [ "$tls_tcp_changed_delta" -le 0 ]; then
+    pass "TLS-terminated TCP service stable: not re-detected as changed across cycles (delta=$tls_tcp_changed_delta)"
+else
+    fail "TLS-terminated TCP service re-detected as changed $tls_tcp_changed_delta time(s) across reconcile cycles (issue #71)"
 fi
 
 # ==============================================================================

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -140,11 +140,12 @@ type TailscaleService struct {
 }
 
 type TailscaleTCPConfig struct {
-	HTTP  bool `json:"HTTP"`
-	HTTPS bool `json:"HTTPS"`
+	HTTP         bool   `json:"HTTP"`
+	HTTPS        bool   `json:"HTTPS"`
+	TerminateTLS string `json:"TerminateTLS"`
 	// TCPForward is the backend address ("host:port") for plain-TCP service
-	// endpoints. HTTP/HTTPS endpoints leave this empty and store their backend
-	// in the Web handler config instead.
+	// and TLS-terminated-TCP endpoints. HTTP/HTTPS endpoints leave this empty
+	// and store their backend in the Web handler config instead.
 	TCPForward string `json:"TCPForward"`
 }
 

--- a/tailscale/service.go
+++ b/tailscale/service.go
@@ -95,6 +95,8 @@ func parseManagedServices(status TailscaleStatus) map[string]ServiceEndpoint {
 // serviceProtocol maps a TCP handler's flags to the DockTail protocol name.
 func serviceProtocol(tcpConfig TailscaleTCPConfig) string {
 	switch {
+	case tcpConfig.TerminateTLS != "":
+		return "tls-terminated-tcp"
 	case tcpConfig.HTTPS:
 		return "https"
 	case tcpConfig.HTTP:
@@ -144,8 +146,10 @@ func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService)
 		protocolFlag = "--http"
 	case "https":
 		protocolFlag = "--https"
-	case "tcp", "tls-terminated-tcp":
+	case "tcp":
 		protocolFlag = "--tcp"
+	case "tls-terminated-tcp":
+		protocolFlag = "--tls-terminated-tcp"
 	default:
 		return fmt.Errorf("unsupported service protocol: %s", svc.ServiceProtocol)
 	}

--- a/tailscale/service_test.go
+++ b/tailscale/service_test.go
@@ -121,6 +121,32 @@ func TestTailscaleStatusParsing(t *testing.T) {
 			},
 		},
 		{
+			name: "TLS-terminated TCP service",
+			input: `{
+				"Services": {
+					"svc:irc": {
+						"TCP": {
+							"6697": {
+								"TCPForward": "172.17.0.6:6667",
+								"TerminateTLS": "irc.example.ts.net"
+							}
+						},
+						"Web": {}
+					}
+				}
+			}`,
+			expectedServices: 1,
+			checkFunc: func(t *testing.T, status TailscaleStatus) {
+				tcpCfg := status.Services["svc:irc"].TCP["6697"]
+				if tcpCfg.TerminateTLS != "irc.example.ts.net" {
+					t.Errorf("expected TerminateTLS to be parsed, got %q", tcpCfg.TerminateTLS)
+				}
+				if tcpCfg.TCPForward != "172.17.0.6:6667" {
+					t.Errorf("expected TCPForward 172.17.0.6:6667, got %q", tcpCfg.TCPForward)
+				}
+			},
+		},
+		{
 			name: "multiple services",
 			input: `{
 				"Services": {
@@ -186,6 +212,15 @@ func TestParseManagedServicesDestinations(t *testing.T) {
 				},
 				Web: map[string]TailscaleWebConfig{},
 			},
+			"svc:irc": {
+				TCP: map[string]TailscaleTCPConfig{
+					"6697": {
+						TCPForward:   "172.17.0.4:6667",
+						TerminateTLS: "irc.example.ts.net",
+					},
+				},
+				Web: map[string]TailscaleWebConfig{},
+			},
 			"manual-service": {
 				// Not managed by DockTail (no svc: prefix) -> ignored.
 				TCP: map[string]TailscaleTCPConfig{
@@ -222,6 +257,17 @@ func TestParseManagedServicesDestinations(t *testing.T) {
 	// The regression: TCP destination must be parsed from TCPForward, not left empty.
 	if db.Destination != "172.17.0.3:5432" {
 		t.Errorf("svc:db destination = %q, want 172.17.0.3:5432 (issue #56)", db.Destination)
+	}
+
+	irc, ok := got["svc:irc:6697"]
+	if !ok {
+		t.Fatal("expected svc:irc:6697 endpoint")
+	}
+	if irc.Protocol != "tls-terminated-tcp" {
+		t.Errorf("svc:irc protocol = %q, want tls-terminated-tcp", irc.Protocol)
+	}
+	if irc.Destination != "172.17.0.4:6667" {
+		t.Errorf("svc:irc destination = %q, want 172.17.0.4:6667", irc.Destination)
 	}
 }
 


### PR DESCRIPTION
## What changed

- pass `--tls-terminated-tcp` when a private service requests TLS-terminated TCP
- parse Tailscale's `TerminateTLS` status field so reconciliation preserves the protocol instead of treating it as plain TCP
- add an E2E service that verifies the live TLS-terminated status and remains stable across reconciliation cycles
- clarify the protocol behavior in the canonical reference documentation

## Why

Private services currently collapse `tls-terminated-tcp` into `--tcp`, silently exposing a plaintext TCP listener. Merely changing the creation flag is insufficient because the status parser would still read the resulting endpoint as plain TCP and reapply it on every reconciliation cycle.

This restores the documented behavior: Tailscale terminates incoming TLS and forwards decrypted TCP to the configured backend.

Closes #71.

## Validation

- `bash -n e2e.sh`
- E2E coverage now asserts the live `TerminateTLS` field and checks stability across at least three reconciliation cycles
- full build, unit, lint, Docker, and E2E validation delegated to this PR's GitHub Actions pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TLS-terminated TCP services.
  * Incoming TLS connections can now be terminated at the edge and forwarded as decrypted TCP traffic to the backend.
  * TLS-terminated TCP services are correctly identified and configured with their dedicated protocol.
  * Added end-to-end coverage for protocol detection, service reconciliation, and idempotency.

* **Documentation**
  * Clarified how TLS termination and backend forwarding work for supported TCP services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->