### PR TITLE
Update Cloud for paid-only activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ environment:
 
 Without the key the module is completely inert: no connection is opened and DockTail behaves exactly as before. The link is outbound-only and metadata-only — the protocol has no exec, deploy, or shell message types, which you can verify in [`cloud/`](cloud/).
 
-[See plans](https://docktail.org/cloud/#pricing) · [open the dashboard](https://cloud.docktail.org/login) · [agent setup](docs/06-cloud.md)
+[Explore DockTail Cloud](https://docktail.org/cloud/) · [open the dashboard](https://cloud.docktail.org/login) · [agent setup](docs/06-cloud.md)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ environment:
 
 Without the key the module is completely inert: no connection is opened and DockTail behaves exactly as before. The link is outbound-only and metadata-only — the protocol has no exec, deploy, or shell message types, which you can verify in [`cloud/`](cloud/).
 
-One host is free, no time limit. [Explore DockTail Cloud](https://docktail.org/cloud/) · [open the dashboard](https://cloud.docktail.org/login) · [agent setup](docs/06-cloud.md)
+[See plans](https://docktail.org/cloud/#pricing) · [open the dashboard](https://cloud.docktail.org/login) · [agent setup](docs/06-cloud.md)
 
 ## Documentation
 

--- a/cloud/collector.go
+++ b/cloud/collector.go
@@ -26,7 +26,7 @@ var agentVersion = "dev"
 const restartLoopThreshold = 3
 
 // unmonitoredSnapshotInterval throttles snapshots for a host the cloud reports
-// as unmonitored (past the workspace plan cap). Such a host stops sending
+// as unmonitored (inactive workspace or past the plan cap). Such a host stops sending
 // checks/events/logs entirely and emits only this occasional catalog-teaser
 // snapshot plus its heartbeat, until the cloud promotes it again.
 const unmonitoredSnapshotInterval = 5 * time.Minute
@@ -56,7 +56,7 @@ type Collector struct {
 	logOverrides map[string]string   // per-service capture mode override (service key -> proto.LogMode*)
 	checkFails   map[string]int      // consecutive local-check failures per service key, for incident log capture
 	cfgVer       int
-	unmonitored  bool      // cloud reports this host past the plan cap; throttle output
+	unmonitored  bool      // cloud reports this host inactive/past the plan cap; throttle output
 	lastTeaser   time.Time // last throttled teaser snapshot sent while unmonitored
 
 	statsMu      sync.Mutex           // guards prevCPU + prevCPUOther

--- a/cloud/proto/messages.go
+++ b/cloud/proto/messages.go
@@ -351,7 +351,7 @@ type Config struct {
 	Logs    LogConfig     `json:"logs"`
 
 	// Unmonitored marks a host the cloud accepts but does not monitor (the
-	// workspace is past its plan host cap). A monitored host omits the field
+	// workspace is inactive or past its plan host cap). A monitored host omits the field
 	// (absent ⇒ monitored, so an old cloud or old agent behaves as before). An
 	// agent that sees Unmonitored should throttle to occasional catalog-teaser
 	// snapshots plus heartbeats and stop emitting checks/events/log excerpts;

--- a/docs/06-cloud.md
+++ b/docs/06-cloud.md
@@ -2,7 +2,7 @@
 
 DockTail Cloud is optional, opt-in monitoring for DockTail-managed services across one or more hosts. It is a hosted dashboard that watches what DockTail exposes and tells you *why* something is unreachable.
 
-[Explore DockTail Cloud](https://docktail.org/cloud/) or [open the dashboard](https://cloud.docktail.org/login). One host is free with no time limit.
+[Explore DockTail Cloud](https://docktail.org/cloud/) or [open the dashboard](https://cloud.docktail.org/login). A new workspace can connect one preview host to verify setup; checks, incidents, and alerts start after a paid plan is activated.
 
 ### What You Get
 
@@ -15,10 +15,15 @@ Reporting rides along with the normal agent — there is no separate binary. The
 
 ### How To Enable
 
-1. Create a workspace in the DockTail Cloud dashboard and copy the workspace key (`dtc_...`).
+1. Create a workspace in the DockTail Cloud dashboard and copy its one-host preview key (`dtc_...`).
 2. Set `DOCKTAIL_CLOUD_KEY` on the DockTail agent.
 
 That is the only configuration — the cloud endpoint is built into the agent.
+
+Before plan activation the connection stays healthy but unmonitored: DockTail
+sends heartbeats and occasional catalog refreshes, while checks, Docker events,
+metrics, tailnet state, and log excerpts remain paused. Activating a plan pushes
+the full configuration to the live connection without reinstalling the agent.
 
 ```yaml
 services:

--- a/docs/06-cloud.md
+++ b/docs/06-cloud.md
@@ -2,7 +2,7 @@
 
 DockTail Cloud is optional, opt-in monitoring for DockTail-managed services across one or more hosts. It is a hosted dashboard that watches what DockTail exposes and tells you *why* something is unreachable.
 
-[Explore DockTail Cloud](https://docktail.org/cloud/) or [open the dashboard](https://cloud.docktail.org/login). A new workspace can connect one preview host to verify setup; checks, incidents, and alerts start after a paid plan is activated.
+[Explore DockTail Cloud](https://docktail.org/cloud/) or [open the dashboard](https://cloud.docktail.org/login).
 
 ### What You Get
 
@@ -15,15 +15,10 @@ Reporting rides along with the normal agent — there is no separate binary. The
 
 ### How To Enable
 
-1. Create a workspace in the DockTail Cloud dashboard and copy its one-host preview key (`dtc_...`).
+1. Create a workspace in the DockTail Cloud dashboard and copy the workspace key (`dtc_...`).
 2. Set `DOCKTAIL_CLOUD_KEY` on the DockTail agent.
 
 That is the only configuration — the cloud endpoint is built into the agent.
-
-Before plan activation the connection stays healthy but unmonitored: DockTail
-sends heartbeats and occasional catalog refreshes, while checks, Docker events,
-metrics, tailnet state, and log excerpts remain paused. Activating a plan pushes
-the full configuration to the live connection without reinstalling the agent.
 
 ```yaml
 services:
@@ -41,6 +36,12 @@ services:
 ```
 
 With no key set, no connection is opened and DockTail runs exactly as before.
+
+If Cloud marks a host as unmonitored (for example, the host sits past the
+workspace's host cap), the agent keeps the connection open with heartbeats and
+occasional catalog snapshots and pauses checks, Docker events, metrics, tailnet
+state, and log excerpts. Cloud pushes an updated configuration over the same
+connection when that changes; the agent does not need a restart.
 
 ### Environment Variables
 

--- a/website/cloud/index.html
+++ b/website/cloud/index.html
@@ -35,9 +35,9 @@
       "url": "https://docktail.org/cloud/",
       "offers": {
         "@type": "Offer",
-        "price": "0",
+        "price": "5",
         "priceCurrency": "USD",
-        "description": "Monitor one host free"
+        "description": "DockTail Cloud Homelab plan"
       },
       "isRelatedTo": {
         "@type": "SoftwareApplication",
@@ -127,7 +127,7 @@
             <div class="flex flex-wrap items-center gap-3 mb-5">
               <a href="https://cloud.docktail.org/login?utm_source=docktail_org&amp;utm_medium=cloud_hero"
                  class="inline-flex items-center px-4 py-2 text-sm tracking-wide bg-gray-900 text-white rounded hover:bg-gray-800 transition-colors">
-                Start free · 1 host
+                Choose a plan
               </a>
               <a href="#how-it-knows"
                  class="inline-flex items-center px-4 py-2 text-sm tracking-wide bg-white text-gray-700 border border-gray-200 rounded hover:border-gray-300 hover:bg-gray-50 transition-colors">
@@ -388,7 +388,7 @@
         <div class="max-w-2xl mb-10">
           <p class="text-xs uppercase tracking-wider text-gray-400 mb-3">Paid plans</p>
           <h2 id="pricing-title" class="text-2xl sm:text-3xl font-bold tracking-tight text-gray-900 mb-4">Plans that grow with your fleet.</h2>
-          <p class="text-sm sm:text-base text-gray-500 leading-relaxed">Start with one monitored host free. Choose a flat plan when your fleet grows — services are not metered.</p>
+          <p class="text-sm sm:text-base text-gray-500 leading-relaxed">Choose a flat plan for your fleet — services and seats are not metered.</p>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-3 gap-5">
@@ -451,11 +451,11 @@
     <section aria-labelledby="cta-title">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
         <div class="rounded-lg border border-gray-800 bg-gray-900 px-6 py-10 sm:px-10 sm:py-12 text-center">
-          <div class="inline-flex items-center gap-2 text-[11px] uppercase tracking-wider text-gray-500 mb-4"><span class="w-1.5 h-1.5 rounded-full bg-green-400"></span> No card required</div>
-          <h2 id="cta-title" class="text-2xl sm:text-3xl font-bold tracking-tight text-white mb-3">Monitor one host for free.</h2>
-          <p class="max-w-xl mx-auto text-sm text-gray-400 leading-relaxed mb-7">One host, free, no time limit — its services, incidents, and one alert channel included. Upgrade when you outgrow it.</p>
+          <div class="inline-flex items-center gap-2 text-[11px] uppercase tracking-wider text-gray-500 mb-4"><span class="w-1.5 h-1.5 rounded-full bg-green-400"></span> Setup preview included</div>
+          <h2 id="cta-title" class="text-2xl sm:text-3xl font-bold tracking-tight text-white mb-3">Connect a host. Activate monitoring.</h2>
+          <p class="max-w-xl mx-auto text-sm text-gray-400 leading-relaxed mb-7">Verify that your agent connects in preview mode, then choose a plan to enable checks, incidents, and alerts.</p>
           <a href="https://cloud.docktail.org/login?utm_source=docktail_org&amp;utm_medium=final_cta"
-             class="inline-flex items-center rounded bg-white px-4 py-2 text-sm text-gray-900 hover:bg-gray-100 transition-colors">Start monitoring · 1 host free</a>
+             class="inline-flex items-center rounded bg-white px-4 py-2 text-sm text-gray-900 hover:bg-gray-100 transition-colors">Connect your first host</a>
         </div>
       </div>
     </section>

--- a/website/cloud/index.html
+++ b/website/cloud/index.html
@@ -399,7 +399,7 @@
               <p class="mt-1 text-xs text-gray-500">A few machines you care about.</p>
             </div>
             <div class="mb-1"><span class="text-3xl font-bold tracking-tight text-gray-900">$5</span><span class="text-sm text-gray-400"> / month</span></div>
-            <div class="text-xs text-gray-400 mb-6">or $50 billed yearly</div>
+            <div class="text-xs text-gray-400 mb-6">or $36 billed yearly</div>
             <ul class="space-y-3 text-sm text-gray-600 mb-7">
               <li class="flex gap-2"><span class="text-gray-400">✓</span> Up to 3 hosts</li>
               <li class="flex gap-2"><span class="text-gray-400">✓</span> 30-day check history</li>

--- a/website/cloud/index.html
+++ b/website/cloud/index.html
@@ -34,10 +34,11 @@
       "description": "Multi-host monitoring and contextual alerting for Docker services exposed by DockTail through Tailscale.",
       "url": "https://docktail.org/cloud/",
       "offers": {
-        "@type": "Offer",
-        "price": "5",
+        "@type": "AggregateOffer",
+        "lowPrice": "5",
+        "highPrice": "29",
         "priceCurrency": "USD",
-        "description": "DockTail Cloud Homelab plan"
+        "offerCount": 2
       },
       "isRelatedTo": {
         "@type": "SoftwareApplication",
@@ -127,14 +128,14 @@
             <div class="flex flex-wrap items-center gap-3 mb-5">
               <a href="https://cloud.docktail.org/login?utm_source=docktail_org&amp;utm_medium=cloud_hero"
                  class="inline-flex items-center px-4 py-2 text-sm tracking-wide bg-gray-900 text-white rounded hover:bg-gray-800 transition-colors">
-                Choose a plan
+                Get started
               </a>
               <a href="#how-it-knows"
                  class="inline-flex items-center px-4 py-2 text-sm tracking-wide bg-white text-gray-700 border border-gray-200 rounded hover:border-gray-300 hover:bg-gray-50 transition-colors">
                 See how it knows
               </a>
             </div>
-            <p class="text-xs text-gray-400">No credit card · same DockTail agent · one environment variable</p>
+            <p class="text-xs text-gray-400">Same DockTail agent · one environment variable · no second binary</p>
           </div>
 
           <!-- Product incident visual -->
@@ -388,7 +389,7 @@
         <div class="max-w-2xl mb-10">
           <p class="text-xs uppercase tracking-wider text-gray-400 mb-3">Paid plans</p>
           <h2 id="pricing-title" class="text-2xl sm:text-3xl font-bold tracking-tight text-gray-900 mb-4">Plans that grow with your fleet.</h2>
-          <p class="text-sm sm:text-base text-gray-500 leading-relaxed">Choose a flat plan for your fleet — services and seats are not metered.</p>
+          <p class="text-sm sm:text-base text-gray-500 leading-relaxed">Flat pricing by host count. Services are not metered — a host reports every service it publishes.</p>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-3 gap-5">
@@ -451,11 +452,11 @@
     <section aria-labelledby="cta-title">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
         <div class="rounded-lg border border-gray-800 bg-gray-900 px-6 py-10 sm:px-10 sm:py-12 text-center">
-          <div class="inline-flex items-center gap-2 text-[11px] uppercase tracking-wider text-gray-500 mb-4"><span class="w-1.5 h-1.5 rounded-full bg-green-400"></span> Setup preview included</div>
-          <h2 id="cta-title" class="text-2xl sm:text-3xl font-bold tracking-tight text-white mb-3">Connect a host. Activate monitoring.</h2>
-          <p class="max-w-xl mx-auto text-sm text-gray-400 leading-relaxed mb-7">Verify that your agent connects in preview mode, then choose a plan to enable checks, incidents, and alerts.</p>
+          <div class="inline-flex items-center gap-2 text-[11px] uppercase tracking-wider text-gray-500 mb-4"><span class="w-1.5 h-1.5 rounded-full bg-green-400"></span> One environment variable</div>
+          <h2 id="cta-title" class="text-2xl sm:text-3xl font-bold tracking-tight text-white mb-3">Start monitoring your fleet.</h2>
+          <p class="max-w-xl mx-auto text-sm text-gray-400 leading-relaxed mb-7">Set <code class="text-gray-300">DOCKTAIL_CLOUD_KEY</code> on the DockTail agent you already run. Every host and service shows up in the dashboard — no second binary, nothing dialing in.</p>
           <a href="https://cloud.docktail.org/login?utm_source=docktail_org&amp;utm_medium=final_cta"
-             class="inline-flex items-center rounded bg-white px-4 py-2 text-sm text-gray-900 hover:bg-gray-100 transition-colors">Connect your first host</a>
+             class="inline-flex items-center rounded bg-white px-4 py-2 text-sm text-gray-900 hover:bg-gray-100 transition-colors">Open DockTail Cloud</a>
         </div>
       </div>
     </section>

--- a/website/index.html
+++ b/website/index.html
@@ -527,7 +527,7 @@
             </a>
             <a href="https://cloud.docktail.org/login?utm_source=docktail_org&amp;utm_medium=homepage_callout"
                class="inline-flex items-center px-4 py-2 text-sm tracking-wide bg-white text-gray-700 border border-gray-200 rounded hover:border-gray-300 hover:bg-gray-50 transition-colors">
-              Start free · 1 host
+              Open the dashboard
             </a>
           </div>
         </div>


### PR DESCRIPTION
## What changed

- remove Free-tier claims from the DockTail README, Cloud docs, and marketing page
- describe the one-host connection preview and paid activation flow
- clarify that unmonitored agents cover inactive workspaces as well as paid-plan overages

## Why

DockTail Cloud no longer offers new Free monitoring workspaces. New users may still connect one host to verify setup, but checks, events, metrics, incidents, and alerts stay paused until a paid plan is activated.

## Developer impact

No configuration or wire-format change is required. Existing agents already honor `Unmonitored: true` by retaining heartbeats and low-rate catalog refreshes while suppressing operational reporting.

## Validation

- `go build ./...`
- `go vet ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud plans now present paid, host-based pricing with updated offer details.
  * Homelab annual pricing is now $36.
  * Unmonitored hosts continue sending heartbeats and occasional catalog snapshots, while active monitoring pauses.
  * Configuration updates can be applied without restarting the agent.

* **Documentation**
  * Updated Cloud documentation and messaging to reflect current plan details and unmonitored-host behavior.
  * Updated calls to action to direct visitors to the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->