### PR TITLE
feat: support PROXY protocol for TCP services

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ DockTail uses native Tailscale Services, not per-container Tailscale devices.
 - Automatic Docker container discovery through labels.
 - Automatic Tailscale service creation with OAuth or API key credentials.
 - HTTP, HTTPS, TCP, and TLS-terminated TCP support.
+- Optional PROXY protocol on TCP services so backends see the tailnet client IP.
 - Tailscale HTTPS with automatic certificates.
 - Tailscale Funnel for public internet access.
 - Multiple Tailscale services from one container.
@@ -99,6 +100,18 @@ labels:
   - "docktail.service.port=5432"
   - "docktail.service.protocol=tcp"
   - "docktail.service.service-port=5432"
+```
+
+Preserve the tailnet client IP on a TCP reverse proxy:
+
+```yaml
+labels:
+  - "docktail.service.enable=true"
+  - "docktail.service.name=traefik"
+  - "docktail.service.port=443"
+  - "docktail.service.protocol=tcp"
+  - "docktail.service.service-port=443"
+  - "docktail.service.proxy-protocol=2"
 ```
 
 Expose a service publicly with Tailscale Funnel:

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -105,6 +105,20 @@ services:
       - "docktail.service.service-port=6697"
       - "docktail.service.service-protocol=tls-terminated-tcp"
 
+  # TCP service with PROXY protocol v2 (issue #77)
+  test-proxy-protocol:
+    image: nginx:alpine
+    container_name: e2e-proxy-protocol
+    restart: "no"
+    labels:
+      - "docktail.service.enable=true"
+      - "docktail.service.name=e2e-proxy-protocol"
+      - "docktail.service.port=80"
+      - "docktail.service.protocol=tcp"
+      - "docktail.service.service-port=8443"
+      - "docktail.service.service-protocol=tcp"
+      - "docktail.service.proxy-protocol=2"
+
   # ============================================================================
   # 2. Smart Defaults
   # ============================================================================

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -119,6 +119,46 @@ services:
       - "docktail.service.service-protocol=tcp"
       - "docktail.service.proxy-protocol=2"
 
+  # HTTP + proxy-protocol must be rejected (service is not advertised)
+  test-proxy-protocol-http:
+    image: nginx:alpine
+    container_name: e2e-proxy-protocol-http
+    restart: "no"
+    labels:
+      - "docktail.service.enable=true"
+      - "docktail.service.name=e2e-proxy-protocol-http"
+      - "docktail.service.port=80"
+      - "docktail.service.proxy-protocol=2"
+
+  # Indexed TCP service carries its own proxy-protocol independently
+  test-proxy-protocol-indexed:
+    image: nginx:alpine
+    container_name: e2e-proxy-protocol-indexed
+    restart: "no"
+    labels:
+      - "docktail.service.enable=true"
+      - "docktail.service.name=e2e-proxy-protocol-web"
+      - "docktail.service.port=80"
+      - "docktail.service.1.name=e2e-proxy-protocol-idx"
+      - "docktail.service.1.port=80"
+      - "docktail.service.1.protocol=tcp"
+      - "docktail.service.1.service-port=9000"
+      - "docktail.service.1.service-protocol=tcp"
+      - "docktail.service.1.proxy-protocol=2"
+
+  # Starts without PROXY protocol; later recreated with the label (issue #77)
+  test-proxy-protocol-change:
+    image: nginx:alpine
+    container_name: e2e-proxy-protocol-change
+    restart: "no"
+    labels:
+      - "docktail.service.enable=true"
+      - "docktail.service.name=e2e-proxy-protocol-change"
+      - "docktail.service.port=80"
+      - "docktail.service.protocol=tcp"
+      - "docktail.service.service-port=9001"
+      - "docktail.service.service-protocol=tcp"
+
   # ============================================================================
   # 2. Smart Defaults
   # ============================================================================

--- a/docker/client.go
+++ b/docker/client.go
@@ -230,6 +230,29 @@ func resolveProtocols(containerID, targetPort, servicePort, serviceProtocol, pro
 	return protocol, servicePort, serviceProtocol, nil
 }
 
+// parseProxyProtocol validates docktail.service.proxy-protocol. Empty means
+// disabled (0). Tailscale only accepts versions 1 or 2, and only on TCP
+// forwarding (service-protocol tcp or tls-terminated-tcp). HTTP/HTTPS must
+// reject the label: Tailscale errors with "PROXY protocol is only supported
+// for TCP forwarding", which would fail every reconcile.
+func parseProxyProtocol(value, serviceProtocol string) (int, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	if serviceProtocol != "tcp" && serviceProtocol != "tls-terminated-tcp" {
+		return 0, fmt.Errorf("docktail.service.proxy-protocol is only supported for TCP forwarding (service-protocol tcp or tls-terminated-tcp), not %s", serviceProtocol)
+	}
+	switch value {
+	case "1":
+		return 1, nil
+	case "2":
+		return 2, nil
+	default:
+		return 0, fmt.Errorf("invalid docktail.service.proxy-protocol: %q (must be 1 or 2)", value)
+	}
+}
+
 // resolveDestPort determines the destination IP and port based on networking mode.
 // Returns (destIP, destPort, error).
 func (c *Client) resolveDestPort(cctx *containerCtx, targetPort string) (string, string, error) {
@@ -760,6 +783,11 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 		cctx.destIP = destIP
 		monIP, monPort := c.monitorTarget(ctx, cctx, targetPort)
 
+		proxyProtocol, err := parseProxyProtocol(labels[apptypes.LabelProxyProtocol], serviceProtocol)
+		if err != nil {
+			return nil, err
+		}
+
 		primary := &apptypes.ContainerService{
 			ContainerID:        cctx.containerID[:12],
 			ContainerName:      cctx.containerName,
@@ -770,6 +798,7 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 			TargetPort:         destPort,
 			ServiceProtocol:    serviceProtocol,
 			Protocol:           protocol,
+			ProxyProtocol:      proxyProtocol,
 			Tags:               cctx.tags,
 			IPAddress:          destIP,
 			MonitorIP:          monIP,
@@ -898,6 +927,17 @@ func (c *Client) parseIndexedPorts(
 			continue
 		}
 
+		idxProxyProtocol, err := parseProxyProtocol(labels[prefix+"proxy-protocol"], serviceProtocol)
+		if err != nil {
+			log.Warn().
+				Err(err).
+				Str("container", cctx.containerName).
+				Str("service", idxServiceName).
+				Int("index", idx).
+				Msg("Invalid proxy-protocol for indexed service, skipping")
+			continue
+		}
+
 		// Check for duplicate service name + port combo
 		dedupKey := idxServiceName + ":" + servicePort
 		if prevIdx, exists := usedServicePorts[dedupKey]; exists {
@@ -943,6 +983,7 @@ func (c *Client) parseIndexedPorts(
 			TargetPort:         idxDestPort,
 			ServiceProtocol:    serviceProtocol,
 			Protocol:           protocol,
+			ProxyProtocol:      idxProxyProtocol,
 			Tags:               cctx.tags,
 			IPAddress:          idxDestIP,
 			MonitorIP:          monIP,

--- a/docker/client_test.go
+++ b/docker/client_test.go
@@ -238,6 +238,95 @@ func TestResolveProtocols(t *testing.T) {
 	}
 }
 
+func TestParseProxyProtocol(t *testing.T) {
+	tests := []struct {
+		name            string
+		value           string
+		serviceProtocol string
+		want            int
+		wantError       bool
+	}{
+		{
+			name:            "unset on tcp",
+			value:           "",
+			serviceProtocol: "tcp",
+			want:            0,
+		},
+		{
+			name:            "unset on https",
+			value:           "",
+			serviceProtocol: "https",
+			want:            0,
+		},
+		{
+			name:            "version 1 on tcp",
+			value:           "1",
+			serviceProtocol: "tcp",
+			want:            1,
+		},
+		{
+			name:            "version 2 on tcp",
+			value:           "2",
+			serviceProtocol: "tcp",
+			want:            2,
+		},
+		{
+			name:            "version 2 on tls-terminated-tcp",
+			value:           "2",
+			serviceProtocol: "tls-terminated-tcp",
+			want:            2,
+		},
+		{
+			name:            "trims whitespace",
+			value:           " 2 ",
+			serviceProtocol: "tcp",
+			want:            2,
+		},
+		{
+			name:            "rejected on http",
+			value:           "2",
+			serviceProtocol: "http",
+			wantError:       true,
+		},
+		{
+			name:            "rejected on https",
+			value:           "1",
+			serviceProtocol: "https",
+			wantError:       true,
+		},
+		{
+			name:            "invalid version",
+			value:           "3",
+			serviceProtocol: "tcp",
+			wantError:       true,
+		},
+		{
+			name:            "non-numeric",
+			value:           "true",
+			serviceProtocol: "tcp",
+			wantError:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseProxyProtocol(tt.value, tt.serviceProtocol)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseProxyProtocol(%q, %q) = %d, want %d", tt.value, tt.serviceProtocol, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManagedContainerDetection(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/docs/04-labels.md
+++ b/docs/04-labels.md
@@ -31,6 +31,7 @@ Set `docktail.service.direct=false` to use published host ports instead. This is
 | `docktail.service.protocol` | No | Smart | Backend protocol. |
 | `docktail.service.service-port` | No | Smart | Port Tailscale listens on. |
 | `docktail.service.service-protocol` | No | Smart | Tailscale-facing protocol. |
+| `docktail.service.proxy-protocol` | No | off | PROXY protocol version (`1` or `2`) prepended on TCP forwards so the backend sees the tailnet client address. Only valid with `service-protocol` `tcp` or `tls-terminated-tcp`. |
 | `docktail.tags` | No | `tag:container` | Comma-separated service tags. Labels are the source of truth; see the note below. |
 
 Tags are synced to the tailnet Service definition through the Tailscale API and require API credentials. Labels are authoritative: DockTail reconciles tags on every cycle, so tags edited by hand in the Tailscale admin console are reverted to the label-declared set on the next reconcile. Containers without a `docktail.tags` label use `DEFAULT_SERVICE_TAGS`.
@@ -40,6 +41,7 @@ Smart defaults:
 - `docktail.service.protocol` defaults to `https` when the backend port is `443`; otherwise it defaults to `http`.
 - `docktail.service.service-port` defaults to `443` when `service-protocol` is `https`; otherwise it defaults to `80`.
 - `docktail.service.service-protocol` defaults to `https` when the service port is `443`, to `tcp` when the backend protocol is TCP, and otherwise to `http`.
+- `docktail.service.proxy-protocol` is opt-in and off by default. The backend must understand PROXY protocol; sending the header to something that does not (Postgres, Redis, raw TCP apps) will break the connection. Set it to `2` unless you specifically need version `1`. The label is rejected on HTTP/HTTPS services because Tailscale only supports PROXY protocol for TCP forwarding.
 
 ### Multiple Services From One Container
 
@@ -57,7 +59,7 @@ services:
       - "docktail.service.1.port=8001"
 ```
 
-Each indexed service requires its own `name` and `port`. Per-index overridable labels are `name`, `port`, `service-port`, `protocol`, `service-protocol`, and `description`. Tags and network settings are inherited from the primary service config.
+Each indexed service requires its own `name` and `port`. Per-index overridable labels are `name`, `port`, `service-port`, `protocol`, `service-protocol`, `proxy-protocol`, and `description`. Tags and network settings are inherited from the primary service config.
 
 ### Funnel Labels
 

--- a/docs/05-examples.md
+++ b/docs/05-examples.md
@@ -82,6 +82,27 @@ services:
       - "docktail.service.service-port=5432"
 ```
 
+### Reverse Proxy With Client IPs (PROXY Protocol)
+
+TCP services normally hide the tailnet client address: the backend sees tailscaled's own IP. Set `docktail.service.proxy-protocol` so Tailscale prepends a [PROXY protocol](https://www.haproxy.com/blog/use-the-proxy-protocol-to-preserve-a-clients-ip-address) header. The backend (Traefik, Caddy, HAProxy, nginx, and similar) must be configured to accept it.
+
+```yaml
+services:
+  traefik:
+    image: traefik:latest
+    labels:
+      - "docktail.service.enable=true"
+      - "docktail.service.name=traefik"
+      - "docktail.service.port=443"
+      - "docktail.service.protocol=tcp"
+      - "docktail.service.service-protocol=tcp"
+      - "docktail.service.service-port=443"
+      - "docktail.service.proxy-protocol=2"
+      - "docktail.service.direct=false"
+```
+
+Without this label, access logs, rate limits, and IP allowlists on the reverse proxy only see tailscaled. HTTP/HTTPS DockTail services cannot use this label; Tailscale rejects PROXY protocol for those modes.
+
 ### Custom Docker Network
 
 ```yaml

--- a/docs/07-reference.md
+++ b/docs/07-reference.md
@@ -59,6 +59,8 @@ Tailscale-facing `docktail.service.service-protocol` values:
 | `tcp` | Layer 4 TCP. |
 | `tls-terminated-tcp` | Layer 4 TCP; Tailscale terminates incoming TLS and forwards decrypted TCP to the backend. |
 
+`docktail.service.proxy-protocol` (`1` or `2`) is valid only with `tcp` or `tls-terminated-tcp`. It is off by default because the backend must understand the PROXY header. HTTP/HTTPS values are rejected.
+
 Container-facing `docktail.service.protocol` values:
 
 | Value | Description |

--- a/docs/08-how-it-works.md
+++ b/docs/08-how-it-works.md
@@ -38,4 +38,6 @@ Direct mode is the default. DockTail reaches containers through their Docker net
 
 When `docktail.service.direct=false`, DockTail uses Docker published port bindings instead. In that mode, the target port must be published to the host.
 
+TCP forwards hide the tailnet client address by default: the backend sees tailscaled. Set `docktail.service.proxy-protocol` to `1` or `2` so Tailscale prepends a PROXY protocol header. The backend must accept that header; HTTP/HTTPS services cannot use it.
+
 Containers using `network_mode: host` are served on `127.0.0.1` (IPv4, to avoid dual-stack `localhost`→`::1` refusals). The local health check probes them from wherever the agent runs: directly via `127.0.0.1` when the agent shares the host's network namespace, or via the agent's docker-network gateway (the host's bridge address) when the agent runs in its own container. Containers using `network_mode: none` cannot use direct mode.

--- a/e2e.sh
+++ b/e2e.sh
@@ -242,6 +242,26 @@ assert_service_protocol() {
     fi
 }
 
+# Check PROXY protocol version on the TCP handler (0 / omitted means unset).
+assert_service_proxy_protocol() {
+    local name="svc:$1"
+    local expected="$2"
+    local port
+    port=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP | keys[0] // empty" 2>/dev/null || true)
+    if [ -z "$port" ]; then
+        fail "$name proxy-protocol check: no TCP config found"
+        return
+    fi
+
+    local actual
+    actual=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP[\"$port\"].ProxyProtocol // 0" 2>/dev/null || echo "0")
+    if [ "$actual" = "$expected" ]; then
+        pass "$name PROXY protocol is $expected"
+    else
+        fail "$name expected PROXY protocol $expected, got $actual"
+    fi
+}
+
 # Check that the destination proxy URL contains a substring
 assert_service_destination_contains() {
     local name="svc:$1"
@@ -505,6 +525,13 @@ assert_service_exists       "e2e-proto-tls-terminated-tcp"
 assert_service_port         "e2e-proto-tls-terminated-tcp" "6697"
 assert_service_protocol     "e2e-proto-tls-terminated-tcp" "tls-terminated-tcp"
 
+echo "  --- TCP with PROXY protocol v2 ---"
+assert_service_exists       "e2e-proxy-protocol"
+assert_service_port         "e2e-proxy-protocol" "8443"
+assert_service_protocol     "e2e-proxy-protocol" "tcp"
+assert_service_proxy_protocol "e2e-proxy-protocol" "2"
+assert_service_proxy_protocol "e2e-proto-tcp" "0"
+
 # ==============================================================================
 # 2. Smart Defaults
 # ==============================================================================
@@ -715,6 +742,7 @@ assert_service_exists       "e2e-proto-http"
 assert_service_exists       "e2e-proto-https"
 assert_service_exists       "e2e-proto-tcp"
 assert_service_exists       "e2e-proto-tls-terminated-tcp"
+assert_service_exists       "e2e-proxy-protocol"
 assert_service_exists       "e2e-default-minimal"
 assert_service_exists       "e2e-net-custom"
 assert_service_exists       "e2e-multiport"
@@ -736,7 +764,9 @@ assert_service_not_exists   "e2e-manual-protected"  # cleaned up explicitly
 # A correctly reconciling TCP service is flagged as "changed" zero times once it
 # has been established. We measure the number of "Service configuration changed"
 # log lines for the TCP service over several reconciliation cycles; with the bug
-# present the count grows by one per cycle, with the fix it stays flat.
+# present the count grows by one per cycle, with the fix it stays flat. The
+# PROXY-protocol service is included so a missing ProxyProtocol field in serve
+# status cannot flap the endpoint every cycle (issue #77).
 
 log "12. TCP Reconciliation Stability (issue #56)"
 
@@ -753,15 +783,21 @@ assert_service_exists       "e2e-proto-tcp"
 assert_service_protocol     "e2e-proto-tcp" "tcp"
 assert_service_exists       "e2e-proto-tls-terminated-tcp"
 assert_service_protocol     "e2e-proto-tls-terminated-tcp" "tls-terminated-tcp"
+assert_service_exists       "e2e-proxy-protocol"
+assert_service_protocol     "e2e-proxy-protocol" "tcp"
+assert_service_proxy_protocol "e2e-proxy-protocol" "2"
 
 echo "  Measuring TCP reconciliation stability across multiple cycles..."
 before_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tcp:5432")
 before_tls_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tls-terminated-tcp:6697")
+before_proxy_changed=$(count_service_changed "key=svc:e2e-proxy-protocol:8443")
 sleep 16   # >= 3 reconcile cycles at RECONCILE_INTERVAL=5s
 after_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tcp:5432")
 after_tls_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tls-terminated-tcp:6697")
+after_proxy_changed=$(count_service_changed "key=svc:e2e-proxy-protocol:8443")
 tcp_changed_delta=$((after_tcp_changed - before_tcp_changed))
 tls_tcp_changed_delta=$((after_tls_tcp_changed - before_tls_tcp_changed))
+proxy_changed_delta=$((after_proxy_changed - before_proxy_changed))
 
 if [ "$tcp_changed_delta" -le 0 ]; then
     pass "TCP service stable: not re-detected as changed across cycles (delta=$tcp_changed_delta)"
@@ -773,6 +809,12 @@ if [ "$tls_tcp_changed_delta" -le 0 ]; then
     pass "TLS-terminated TCP service stable: not re-detected as changed across cycles (delta=$tls_tcp_changed_delta)"
 else
     fail "TLS-terminated TCP service re-detected as changed $tls_tcp_changed_delta time(s) across reconcile cycles (issue #71)"
+fi
+
+if [ "$proxy_changed_delta" -le 0 ]; then
+    pass "PROXY-protocol TCP service stable: not re-detected as changed across cycles (delta=$proxy_changed_delta)"
+else
+    fail "PROXY-protocol TCP service re-detected as changed $proxy_changed_delta time(s) across reconcile cycles (issue #77: ProxyProtocol not parsed from serve status)"
 fi
 
 # ==============================================================================

--- a/e2e.sh
+++ b/e2e.sh
@@ -145,6 +145,33 @@ wait_for_service_state() {
     return 1
 }
 
+# Poll until a TCP handler reports the expected PROXY protocol version.
+# 0 / omitted means the header is not being sent. Used after label changes
+# because container replacement briefly drains the old serve config.
+wait_for_proxy_protocol() {
+    local name="svc:$1"
+    local expected="$2"
+    local timeout="${3:-30}"
+    local elapsed=0
+    local port actual
+
+    while [ "$elapsed" -lt "$timeout" ]; do
+        refresh_serve_status
+        port=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP | keys[0] // empty" 2>/dev/null || true)
+        if [ -n "$port" ]; then
+            actual=$(echo "$SERVE_STATUS_CACHE" | jq -r ".Services[\"$name\"].TCP[\"$port\"].ProxyProtocol // 0" 2>/dev/null || echo "0")
+            if [ "$actual" = "$expected" ]; then
+                return 0
+            fi
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    fail "$name did not converge to PROXY protocol $expected within ${timeout}s"
+    return 1
+}
+
 # Check if a service exists in the serve status
 assert_service_exists() {
     local name="svc:$1"
@@ -532,6 +559,25 @@ assert_service_protocol     "e2e-proxy-protocol" "tcp"
 assert_service_proxy_protocol "e2e-proxy-protocol" "2"
 assert_service_proxy_protocol "e2e-proto-tcp" "0"
 
+echo "  --- HTTP + proxy-protocol is rejected ---"
+assert_service_not_exists   "e2e-proxy-protocol-http"
+wait_for_docktail_log "docktail.service.proxy-protocol is only supported for TCP forwarding"
+
+echo "  --- Indexed TCP service has its own proxy-protocol ---"
+assert_service_exists       "e2e-proxy-protocol-web"
+assert_service_protocol     "e2e-proxy-protocol-web" "http"
+assert_service_proxy_protocol "e2e-proxy-protocol-web" "0"
+assert_service_exists       "e2e-proxy-protocol-idx"
+assert_service_port         "e2e-proxy-protocol-idx" "9000"
+assert_service_protocol     "e2e-proxy-protocol-idx" "tcp"
+assert_service_proxy_protocol "e2e-proxy-protocol-idx" "2"
+
+echo "  --- Change fixture starts without PROXY protocol ---"
+assert_service_exists       "e2e-proxy-protocol-change"
+assert_service_port         "e2e-proxy-protocol-change" "9001"
+assert_service_protocol     "e2e-proxy-protocol-change" "tcp"
+assert_service_proxy_protocol "e2e-proxy-protocol-change" "0"
+
 # ==============================================================================
 # 2. Smart Defaults
 # ==============================================================================
@@ -743,6 +789,10 @@ assert_service_exists       "e2e-proto-https"
 assert_service_exists       "e2e-proto-tcp"
 assert_service_exists       "e2e-proto-tls-terminated-tcp"
 assert_service_exists       "e2e-proxy-protocol"
+assert_service_exists       "e2e-proxy-protocol-web"
+assert_service_exists       "e2e-proxy-protocol-idx"
+assert_service_exists       "e2e-proxy-protocol-change"
+assert_service_not_exists   "e2e-proxy-protocol-http"
 assert_service_exists       "e2e-default-minimal"
 assert_service_exists       "e2e-net-custom"
 assert_service_exists       "e2e-multiport"
@@ -786,18 +836,24 @@ assert_service_protocol     "e2e-proto-tls-terminated-tcp" "tls-terminated-tcp"
 assert_service_exists       "e2e-proxy-protocol"
 assert_service_protocol     "e2e-proxy-protocol" "tcp"
 assert_service_proxy_protocol "e2e-proxy-protocol" "2"
+assert_service_exists       "e2e-proxy-protocol-idx"
+assert_service_protocol     "e2e-proxy-protocol-idx" "tcp"
+assert_service_proxy_protocol "e2e-proxy-protocol-idx" "2"
 
 echo "  Measuring TCP reconciliation stability across multiple cycles..."
 before_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tcp:5432")
 before_tls_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tls-terminated-tcp:6697")
 before_proxy_changed=$(count_service_changed "key=svc:e2e-proxy-protocol:8443")
+before_idx_proxy_changed=$(count_service_changed "key=svc:e2e-proxy-protocol-idx:9000")
 sleep 16   # >= 3 reconcile cycles at RECONCILE_INTERVAL=5s
 after_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tcp:5432")
 after_tls_tcp_changed=$(count_service_changed "key=svc:e2e-proto-tls-terminated-tcp:6697")
 after_proxy_changed=$(count_service_changed "key=svc:e2e-proxy-protocol:8443")
+after_idx_proxy_changed=$(count_service_changed "key=svc:e2e-proxy-protocol-idx:9000")
 tcp_changed_delta=$((after_tcp_changed - before_tcp_changed))
 tls_tcp_changed_delta=$((after_tls_tcp_changed - before_tls_tcp_changed))
 proxy_changed_delta=$((after_proxy_changed - before_proxy_changed))
+idx_proxy_changed_delta=$((after_idx_proxy_changed - before_idx_proxy_changed))
 
 if [ "$tcp_changed_delta" -le 0 ]; then
     pass "TCP service stable: not re-detected as changed across cycles (delta=$tcp_changed_delta)"
@@ -815,6 +871,12 @@ if [ "$proxy_changed_delta" -le 0 ]; then
     pass "PROXY-protocol TCP service stable: not re-detected as changed across cycles (delta=$proxy_changed_delta)"
 else
     fail "PROXY-protocol TCP service re-detected as changed $proxy_changed_delta time(s) across reconcile cycles (issue #77: ProxyProtocol not parsed from serve status)"
+fi
+
+if [ "$idx_proxy_changed_delta" -le 0 ]; then
+    pass "Indexed PROXY-protocol TCP service stable: not re-detected as changed across cycles (delta=$idx_proxy_changed_delta)"
+else
+    fail "Indexed PROXY-protocol TCP service re-detected as changed $idx_proxy_changed_delta time(s) across reconcile cycles (issue #77)"
 fi
 
 # ==============================================================================
@@ -1001,10 +1063,89 @@ else
 fi
 
 # ==============================================================================
-# 16. Log Health
+# 16. PROXY Protocol Label Changes (issue #77)
+# ==============================================================================
+#
+# https://github.com/marvinvr/docktail/issues/77
+# Enabling, changing, or removing docktail.service.proxy-protocol must update
+# the advertised Tailscale serve config. This is the live counterpart of the
+# unit tests that compare ProxyProtocol from `serve status --json`.
+
+log "16. PROXY Protocol Label Changes (issue #77)"
+
+echo "  --- Pre-check: change fixture is TCP without PROXY protocol ---"
+refresh_serve_status
+assert_service_exists       "e2e-proxy-protocol-change"
+assert_service_protocol     "e2e-proxy-protocol-change" "tcp"
+assert_service_proxy_protocol "e2e-proxy-protocol-change" "0"
+
+echo "  --- Recreating container with proxy-protocol=2 ---"
+docker stop e2e-proxy-protocol-change >/dev/null 2>&1 || true
+docker rm e2e-proxy-protocol-change >/dev/null 2>&1 || true
+docker run -d \
+    --name e2e-proxy-protocol-change \
+    --restart no \
+    --label "docktail.service.enable=true" \
+    --label "docktail.service.name=e2e-proxy-protocol-change" \
+    --label "docktail.service.port=80" \
+    --label "docktail.service.protocol=tcp" \
+    --label "docktail.service.service-port=9001" \
+    --label "docktail.service.service-protocol=tcp" \
+    --label "docktail.service.proxy-protocol=2" \
+    nginx:alpine >/dev/null 2>&1
+
+wait_for_proxy_protocol "e2e-proxy-protocol-change" "2" "$((RECONCILE_WAIT * 3))"
+assert_service_exists       "e2e-proxy-protocol-change"
+assert_service_protocol     "e2e-proxy-protocol-change" "tcp"
+assert_service_proxy_protocol "e2e-proxy-protocol-change" "2"
+
+echo "  --- Changing proxy-protocol from 2 to 1 ---"
+docker stop e2e-proxy-protocol-change >/dev/null 2>&1 || true
+docker rm e2e-proxy-protocol-change >/dev/null 2>&1 || true
+docker run -d \
+    --name e2e-proxy-protocol-change \
+    --restart no \
+    --label "docktail.service.enable=true" \
+    --label "docktail.service.name=e2e-proxy-protocol-change" \
+    --label "docktail.service.port=80" \
+    --label "docktail.service.protocol=tcp" \
+    --label "docktail.service.service-port=9001" \
+    --label "docktail.service.service-protocol=tcp" \
+    --label "docktail.service.proxy-protocol=1" \
+    nginx:alpine >/dev/null 2>&1
+
+wait_for_proxy_protocol "e2e-proxy-protocol-change" "1" "$((RECONCILE_WAIT * 3))"
+assert_service_proxy_protocol "e2e-proxy-protocol-change" "1"
+
+echo "  --- Removing proxy-protocol restores a plain TCP forward ---"
+docker stop e2e-proxy-protocol-change >/dev/null 2>&1 || true
+docker rm e2e-proxy-protocol-change >/dev/null 2>&1 || true
+docker run -d \
+    --name e2e-proxy-protocol-change \
+    --restart no \
+    --label "docktail.service.enable=true" \
+    --label "docktail.service.name=e2e-proxy-protocol-change" \
+    --label "docktail.service.port=80" \
+    --label "docktail.service.protocol=tcp" \
+    --label "docktail.service.service-port=9001" \
+    --label "docktail.service.service-protocol=tcp" \
+    nginx:alpine >/dev/null 2>&1
+
+wait_for_proxy_protocol "e2e-proxy-protocol-change" "0" "$((RECONCILE_WAIT * 3))"
+assert_service_exists       "e2e-proxy-protocol-change"
+assert_service_protocol     "e2e-proxy-protocol-change" "tcp"
+assert_service_proxy_protocol "e2e-proxy-protocol-change" "0"
+
+echo "  --- Other PROXY-protocol services unaffected ---"
+assert_service_proxy_protocol "e2e-proxy-protocol" "2"
+assert_service_proxy_protocol "e2e-proxy-protocol-idx" "2"
+assert_service_not_exists   "e2e-proxy-protocol-http"
+
+# ==============================================================================
+# 17. Log Health
 # ==============================================================================
 
-log "16. DockTail Log Health"
+log "17. DockTail Log Health"
 docktail_logs=$(docker logs "$DOCKTAIL_CONTAINER" 2>&1)
 
 if grep -qE "FATAL|panic" <<<"$docktail_logs"; then

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -123,10 +123,11 @@ func (t *apiKeyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // ServiceEndpoint represents a single endpoint for comparison
 type ServiceEndpoint struct {
-	ServiceName string // e.g., "svc:web"
-	Port        string // e.g., "443"
-	Protocol    string // e.g., "http", "https", "tcp"
-	Destination string // e.g., "http://localhost:9080"
+	ServiceName   string // e.g., "svc:web"
+	Port          string // e.g., "443"
+	Protocol      string // e.g., "http", "https", "tcp"
+	Destination   string // e.g., "http://localhost:9080"
+	ProxyProtocol int    // 0, 1, or 2 as reported by `tailscale serve status`
 }
 
 // TailscaleStatus represents the structure of 'tailscale serve status --json'
@@ -147,6 +148,9 @@ type TailscaleTCPConfig struct {
 	// and TLS-terminated-TCP endpoints. HTTP/HTTPS endpoints leave this empty
 	// and store their backend in the Web handler config instead.
 	TCPForward string `json:"TCPForward"`
+	// ProxyProtocol is the PROXY protocol version prepended on TCP forwards.
+	// Omitted (0) when Tailscale is not sending a PROXY header.
+	ProxyProtocol int `json:"ProxyProtocol"`
 }
 
 type TailscaleWebConfig struct {
@@ -210,16 +214,17 @@ func (c *Client) ReconcileServices(ctx context.Context, desiredServices []*appty
 				Msg("Service not found in current state, will add")
 		} else {
 			// Service exists - check if configuration changed
-			expectedDest := buildDestination(desired)
-			if !sameDestination(current.Destination, expectedDest) || current.Protocol != desired.ServiceProtocol {
+			if serviceConfigChanged(current, desired) {
 				toAdd[key] = desired
 				log.Info().
 					Str("key", key).
 					Str("service", desired.ServiceName).
 					Str("current_dest", current.Destination).
-					Str("expected_dest", expectedDest).
+					Str("expected_dest", buildDestination(desired)).
 					Str("current_protocol", current.Protocol).
 					Str("expected_protocol", desired.ServiceProtocol).
+					Int("current_proxy_protocol", current.ProxyProtocol).
+					Int("expected_proxy_protocol", desired.ProxyProtocol).
 					Msg("Service configuration changed, will update")
 			} else {
 				// Service exists and matches - no action needed

--- a/tailscale/service.go
+++ b/tailscale/service.go
@@ -74,10 +74,11 @@ func parseManagedServices(status TailscaleStatus) map[string]ServiceEndpoint {
 			key := fmt.Sprintf("%s:%s", serviceName, port)
 
 			services[key] = ServiceEndpoint{
-				ServiceName: serviceName,
-				Port:        port,
-				Protocol:    protocol,
-				Destination: destination,
+				ServiceName:   serviceName,
+				Port:          port,
+				Protocol:      protocol,
+				Destination:   destination,
+				ProxyProtocol: tcpConfig.ProxyProtocol,
 			}
 
 			log.Debug().
@@ -132,14 +133,13 @@ func serviceDestination(svcConfig TailscaleService, port string, tcpConfig Tails
 	return ""
 }
 
-// addService adds a single service using Tailscale CLI
-// NOTE: This does NOT drain by default - draining only happens when needed
-// If adding fails due to config conflict, it clears (with drain) and retries
-func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService) error {
+// serveAddArgs builds `tailscale serve` arguments for advertising one service.
+// --proxy-protocol is included only when the label requested a version; Tailscale
+// rejects that flag on HTTP/HTTPS, so callers must already have validated it.
+func serveAddArgs(svc *apptypes.ContainerService) ([]string, error) {
 	serviceName := fmt.Sprintf("svc:%s", svc.ServiceName)
 	destination := buildDestination(svc)
 
-	// Map service protocol to CLI flag (this is what Tailscale exposes)
 	var protocolFlag string
 	switch svc.ServiceProtocol {
 	case "http":
@@ -151,14 +151,33 @@ func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService)
 	case "tls-terminated-tcp":
 		protocolFlag = "--tls-terminated-tcp"
 	default:
-		return fmt.Errorf("unsupported service protocol: %s", svc.ServiceProtocol)
+		return nil, fmt.Errorf("unsupported service protocol: %s", svc.ServiceProtocol)
 	}
 
-	// Build the command: tailscale serve --service=svc:<name> --<protocol>=<port> <destination>
-	portArg := fmt.Sprintf("%s=%s", protocolFlag, svc.Port)
-	serviceArg := fmt.Sprintf("--service=%s", serviceName)
+	args := []string{
+		"serve",
+		fmt.Sprintf("--service=%s", serviceName),
+		fmt.Sprintf("%s=%s", protocolFlag, svc.Port),
+	}
+	if svc.ProxyProtocol != 0 {
+		args = append(args, fmt.Sprintf("--proxy-protocol=%d", svc.ProxyProtocol))
+	}
+	args = append(args, destination)
+	return args, nil
+}
 
-	cmd := c.tailscaleCmd(ctx, "serve", serviceArg, portArg, destination)
+// addService adds a single service using Tailscale CLI
+// NOTE: This does NOT drain by default - draining only happens when needed
+// If adding fails due to config conflict, it clears (with drain) and retries
+func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService) error {
+	args, err := serveAddArgs(svc)
+	if err != nil {
+		return err
+	}
+	serviceName := fmt.Sprintf("svc:%s", svc.ServiceName)
+	destination := buildDestination(svc)
+
+	cmd := c.tailscaleCmd(ctx, args...)
 
 	log.Debug().
 		Str("command", cmd.String()).
@@ -166,6 +185,7 @@ func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService)
 		Str("service_protocol", svc.ServiceProtocol).
 		Str("service_port", svc.Port).
 		Str("backend_protocol", svc.Protocol).
+		Int("proxy_protocol", svc.ProxyProtocol).
 		Str("destination", destination).
 		Msg("Executing tailscale serve command")
 
@@ -190,7 +210,7 @@ func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService)
 				Str("service", serviceName).
 				Msg("Retrying add after clearing conflicting config")
 
-			retryCmd := c.tailscaleCmd(ctx, "serve", serviceArg, portArg, destination)
+			retryCmd := c.tailscaleCmd(ctx, args...)
 			retryOutput, retryErr := retryCmd.CombinedOutput()
 			if retryErr != nil {
 				return fmt.Errorf("failed to add service after clearing: %w\nOutput: %s", retryErr, string(retryOutput))

--- a/tailscale/service_test.go
+++ b/tailscale/service_test.go
@@ -118,6 +118,35 @@ func TestTailscaleStatusParsing(t *testing.T) {
 				if tcpCfg.TCPForward != "172.17.0.5:5432" {
 					t.Errorf("expected TCPForward 172.17.0.5:5432, got %q", tcpCfg.TCPForward)
 				}
+				if tcpCfg.ProxyProtocol != 0 {
+					t.Errorf("expected ProxyProtocol 0 when omitted, got %d", tcpCfg.ProxyProtocol)
+				}
+			},
+		},
+		{
+			name: "TCP service with PROXY protocol v2",
+			input: `{
+				"Services": {
+					"svc:traefik": {
+						"TCP": {
+							"443": {
+								"TCPForward": "172.17.0.8:443",
+								"ProxyProtocol": 2
+							}
+						},
+						"Web": {}
+					}
+				}
+			}`,
+			expectedServices: 1,
+			checkFunc: func(t *testing.T, status TailscaleStatus) {
+				tcpCfg := status.Services["svc:traefik"].TCP["443"]
+				if tcpCfg.ProxyProtocol != 2 {
+					t.Errorf("expected ProxyProtocol 2, got %d", tcpCfg.ProxyProtocol)
+				}
+				if tcpCfg.TCPForward != "172.17.0.8:443" {
+					t.Errorf("expected TCPForward 172.17.0.8:443, got %q", tcpCfg.TCPForward)
+				}
 			},
 		},
 		{
@@ -221,6 +250,15 @@ func TestParseManagedServicesDestinations(t *testing.T) {
 				},
 				Web: map[string]TailscaleWebConfig{},
 			},
+			"svc:traefik": {
+				TCP: map[string]TailscaleTCPConfig{
+					"443": {
+						TCPForward:    "172.17.0.8:443",
+						ProxyProtocol: 2,
+					},
+				},
+				Web: map[string]TailscaleWebConfig{},
+			},
 			"manual-service": {
 				// Not managed by DockTail (no svc: prefix) -> ignored.
 				TCP: map[string]TailscaleTCPConfig{
@@ -268,6 +306,151 @@ func TestParseManagedServicesDestinations(t *testing.T) {
 	}
 	if irc.Destination != "172.17.0.4:6667" {
 		t.Errorf("svc:irc destination = %q, want 172.17.0.4:6667", irc.Destination)
+	}
+	if irc.ProxyProtocol != 0 {
+		t.Errorf("svc:irc proxy protocol = %d, want 0", irc.ProxyProtocol)
+	}
+
+	traefik, ok := got["svc:traefik:443"]
+	if !ok {
+		t.Fatal("expected svc:traefik:443 endpoint")
+	}
+	if traefik.Protocol != "tcp" {
+		t.Errorf("svc:traefik protocol = %q, want tcp", traefik.Protocol)
+	}
+	if traefik.Destination != "172.17.0.8:443" {
+		t.Errorf("svc:traefik destination = %q, want 172.17.0.8:443", traefik.Destination)
+	}
+	if traefik.ProxyProtocol != 2 {
+		t.Errorf("svc:traefik proxy protocol = %d, want 2", traefik.ProxyProtocol)
+	}
+}
+
+func TestServeAddArgs(t *testing.T) {
+	base := apptypes.ContainerService{
+		ServiceName:     "db",
+		Port:            "5432",
+		Protocol:        "tcp",
+		ServiceProtocol: "tcp",
+		IPAddress:       "172.17.0.5",
+		TargetPort:      "5432",
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*apptypes.ContainerService)
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "tcp without proxy protocol",
+			want: []string{"serve", "--service=svc:db", "--tcp=5432", "tcp://172.17.0.5:5432"},
+		},
+		{
+			name: "tcp with proxy protocol 2",
+			mutate: func(svc *apptypes.ContainerService) {
+				svc.ProxyProtocol = 2
+			},
+			want: []string{"serve", "--service=svc:db", "--tcp=5432", "--proxy-protocol=2", "tcp://172.17.0.5:5432"},
+		},
+		{
+			name: "tls-terminated-tcp with proxy protocol 1",
+			mutate: func(svc *apptypes.ContainerService) {
+				svc.ServiceProtocol = "tls-terminated-tcp"
+				svc.ProxyProtocol = 1
+			},
+			want: []string{"serve", "--service=svc:db", "--tls-terminated-tcp=5432", "--proxy-protocol=1", "tcp://172.17.0.5:5432"},
+		},
+		{
+			name: "https never emits proxy protocol when unset",
+			mutate: func(svc *apptypes.ContainerService) {
+				svc.ServiceName = "api"
+				svc.Port = "443"
+				svc.Protocol = "http"
+				svc.ServiceProtocol = "https"
+				svc.TargetPort = "3000"
+			},
+			want: []string{"serve", "--service=svc:api", "--https=443", "http://172.17.0.5:3000"},
+		},
+		{
+			name: "unsupported protocol",
+			mutate: func(svc *apptypes.ContainerService) {
+				svc.ServiceProtocol = "udp"
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := base
+			if tt.mutate != nil {
+				tt.mutate(&svc)
+			}
+			got, err := serveAddArgs(&svc)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("serveAddArgs() = %#v, want %#v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("serveAddArgs() = %#v, want %#v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestServiceConfigChanged(t *testing.T) {
+	desired := &apptypes.ContainerService{
+		ServiceName:     "db",
+		Port:            "5432",
+		Protocol:        "tcp",
+		ServiceProtocol: "tcp",
+		IPAddress:       "172.17.0.5",
+		TargetPort:      "5432",
+		ProxyProtocol:   2,
+	}
+	current := ServiceEndpoint{
+		ServiceName:   "svc:db",
+		Port:          "5432",
+		Protocol:      "tcp",
+		Destination:   "172.17.0.5:5432",
+		ProxyProtocol: 2,
+	}
+
+	if serviceConfigChanged(current, desired) {
+		t.Fatal("matching proxy-protocol config should not look changed")
+	}
+
+	current.ProxyProtocol = 0
+	if !serviceConfigChanged(current, desired) {
+		t.Fatal("enabling proxy-protocol should be detected as a change")
+	}
+
+	current.ProxyProtocol = 1
+	if !serviceConfigChanged(current, desired) {
+		t.Fatal("changing proxy-protocol version should be detected as a change")
+	}
+
+	desired.ProxyProtocol = 0
+	current.ProxyProtocol = 2
+	if !serviceConfigChanged(current, desired) {
+		t.Fatal("removing proxy-protocol should be detected as a change")
+	}
+
+	desired.ProxyProtocol = 0
+	current.ProxyProtocol = 0
+	if serviceConfigChanged(current, desired) {
+		t.Fatal("matching config without proxy-protocol should not look changed")
 	}
 }
 

--- a/tailscale/utils.go
+++ b/tailscale/utils.go
@@ -169,3 +169,14 @@ func buildDestination(svc *apptypes.ContainerService) string {
 	// The protocol flag and destination protocol should match the service configuration
 	return fmt.Sprintf("%s://%s:%s", svc.Protocol, svc.IPAddress, svc.TargetPort)
 }
+
+// serviceConfigChanged reports whether the advertised endpoint differs from the
+// desired container labels. Destination, Tailscale-facing protocol, and PROXY
+// protocol version are all compared so enabling, changing, or removing
+// --proxy-protocol is picked up on the next reconcile.
+func serviceConfigChanged(current ServiceEndpoint, desired *apptypes.ContainerService) bool {
+	expectedDest := buildDestination(desired)
+	return !sameDestination(current.Destination, expectedDest) ||
+		current.Protocol != desired.ServiceProtocol ||
+		current.ProxyProtocol != desired.ProxyProtocol
+}

--- a/types/types.go
+++ b/types/types.go
@@ -22,8 +22,13 @@ type ContainerService struct {
 	//   - host-network mode:   the docker host gateway and the container port.
 	// Empty for direct mode (IPAddress is already the container IP), when the agent
 	// itself shares the host netns (127.0.0.1 works), or when nothing is resolvable.
-	MonitorIP        string
-	MonitorPort      string
+	MonitorIP   string
+	MonitorPort string
+	// ProxyProtocol is the PROXY protocol version Tailscale should prepend on
+	// TCP forwards (1 or 2). Zero means the header is not sent. Only valid
+	// with service-protocol tcp or tls-terminated-tcp; HTTP/HTTPS
+	// service-protocol must not set this, or Tailscale serve rejects the config.
+	ProxyProtocol    int
 	FunnelEnabled    bool   // Enable Tailscale Funnel (public internet access)
 	FunnelPort       string // Container port for funnel (separate from service port)
 	FunnelTargetPort string // Host port that maps to FunnelPort
@@ -52,6 +57,7 @@ const (
 	LabelServiceProtocol  = "docktail.service.service-protocol"
 	LabelTarget           = "docktail.service.port"
 	LabelTargetProtocol   = "docktail.service.protocol"
+	LabelProxyProtocol    = "docktail.service.proxy-protocol"
 	LabelTags             = "docktail.tags"
 	LabelFunnelEnable     = "docktail.funnel.enable"
 	LabelFunnelPort       = "docktail.funnel.port"        // Container port (like service.port)


### PR DESCRIPTION
Fixes #77.

TCP services currently hide the tailnet client address. The backend sees tailscaled's own IP, so access logs, rate limits, and IP allowlists are useless when DockTail sits in front of a reverse proxy such as Traefik.

This adds `docktail.service.proxy-protocol=1|2`, which is passed through as `tailscale serve --proxy-protocol`. Tailscale already supports that flag for TCP forwarding.

## Behavior

- Opt-in label, not a default. PROXY protocol will break backends that do not understand the header (Postgres, Redis, raw TCP). Version `2` is the usual choice.
- Allowed only with `service-protocol` `tcp` or `tls-terminated-tcp`. HTTP/HTTPS is rejected at parse time so Tailscale does not fail the reconcile.
- Works on primary and indexed services (`docktail.service.N.proxy-protocol`).
- `serve status --json` is parsed for `ProxyProtocol`, so enabling, changing, or removing the label is detected as drift instead of being ignored or flapping every cycle.

## Example

```yaml
labels:
  - "docktail.service.enable=true"
  - "docktail.service.name=traefik"
  - "docktail.service.port=443"
  - "docktail.service.protocol=tcp"
  - "docktail.service.service-port=443"
  - "docktail.service.proxy-protocol=2"
```

The backend must be configured to accept PROXY protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional PROXY protocol support for TCP services, including versions 1 and 2.
  - TCP backends can receive the original client IP when configured and supported.
  - Added configuration through the `docktail.service.proxy-protocol` label, including per-service overrides.
  - Service changes are detected and applied automatically, while unsupported HTTP/HTTPS configurations are rejected.

- **Documentation**
  - Added setup guidance, compatibility requirements, examples, and configuration references.

- **Tests**
  - Expanded coverage for parsing, reconciliation, validation, and end-to-end PROXY protocol behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->