### PR TITLE
Explain rootless Docker serve-config denial (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker compose up -d
 curl http://myapp.your-tailnet.ts.net
 ```
 
-This assumes the Docker host is connected to Tailscale and allowed to advertise services. See the full docs for host setup, sidecar setup, OAuth permissions, ACLs, labels, Funnel, and examples.
+This assumes the Docker host is connected to Tailscale and allowed to advertise services. See the full docs for host setup, sidecar setup, rootless Docker, OAuth permissions, ACLs, labels, Funnel, and examples.
 
 For Docker secrets or other mounted secret files, set `FILE__TAILSCALE_OAUTH_CLIENT_ID` / `FILE__TAILSCALE_OAUTH_CLIENT_SECRET` or `TAILSCALE_OAUTH_CLIENT_ID_FILE` / `TAILSCALE_OAUTH_CLIENT_SECRET_FILE` to the mounted file paths instead of putting the values directly in the environment.
 

--- a/docs/01-quick-start.md
+++ b/docs/01-quick-start.md
@@ -36,4 +36,4 @@ Then open the service from your tailnet:
 curl http://myapp.your-tailnet.ts.net
 ```
 
-This assumes a Linux Docker host that is already connected to Tailscale and allowed to advertise services. If it is not, continue with [Installation](#installation) and [Tailscale Admin Setup](#tailscale-admin-setup). On macOS and Windows the host's Tailscale daemon cannot be shared with containers, so use the [Tailscale Sidecar](#tailscale-sidecar) setup instead.
+This assumes a Linux Docker host that is already connected to Tailscale and allowed to advertise services. If it is not, continue with [Installation](#installation) and [Tailscale Admin Setup](#tailscale-admin-setup). On macOS and Windows the host's Tailscale daemon cannot be shared with containers, so use the [Tailscale Sidecar](#tailscale-sidecar) setup instead. Rootless Docker on Linux needs an extra operator step; see [Rootless Docker](#rootless-docker).

--- a/docs/01-quick-start.md
+++ b/docs/01-quick-start.md
@@ -36,4 +36,4 @@ Then open the service from your tailnet:
 curl http://myapp.your-tailnet.ts.net
 ```
 
-This assumes a Linux Docker host that is already connected to Tailscale and allowed to advertise services. If it is not, continue with [Installation](#installation) and [Tailscale Admin Setup](#tailscale-admin-setup). On macOS and Windows the host's Tailscale daemon cannot be shared with containers, so use the [Tailscale Sidecar](#tailscale-sidecar) setup instead. Rootless Docker on Linux needs an extra operator step; see [Rootless Docker](#rootless-docker).
+This assumes a Linux Docker host that is already connected to Tailscale and allowed to advertise services. If it is not, continue with [Installation](02-installation.md#installation) and [Tailscale Admin Setup](03-tailscale-admin.md#tailscale-admin-setup). On macOS and Windows the host's Tailscale daemon cannot be shared with containers, so use the [Tailscale Sidecar](02-installation.md#tailscale-sidecar) setup instead. Rootless Docker on Linux needs an extra operator step; see [Rootless Docker](02-installation.md#rootless-docker).

--- a/docs/02-installation.md
+++ b/docs/02-installation.md
@@ -31,6 +31,37 @@ sudo tailscale up --advertise-tags=tag:server --reset
 
 The `--reset` flag briefly drops the Tailscale connection. If you are connected through SSH over Tailscale, your session may be interrupted until Tailscale reconnects.
 
+### Rootless Docker
+
+When Docker runs rootless, the DockTail container is your user, not root. Host `tailscaled` then rejects serve-config writes unless that user is the Tailscale operator:
+
+```bash
+sudo tailscale set --operator=$USER
+```
+
+`tailscale set --operator` does not drop the connection. The node still needs the ACL tag from the host setup above. If it is not tagged yet:
+
+```bash
+sudo tailscale up --advertise-tags=tag:server --operator=$USER --reset
+```
+
+`--operator` lets that Unix user manage `tailscaled` (serve, Funnel, `up`/`down`). That is required for the host setup with rootless Docker. If you do not want to grant the Docker user that access, use the [Tailscale Sidecar](#tailscale-sidecar) instead.
+
+Rootless Docker also changes two paths:
+
+**Docker socket.** Mount the user socket, not `/var/run/docker.sock`. Replace `1000` with your UID (`id -u`):
+
+```yaml
+volumes:
+  - /run/user/1000/docker.sock:/var/run/docker.sock:ro
+  - /var/run/tailscale:/var/run/tailscale
+```
+
+**Container reachability.** Default direct mode tells host `tailscaled` to connect to the container IP. Those IPs are often unreachable from the host in rootless Docker. If the service advertises but does not connect:
+
+- Set `docktail.service.direct=false` and publish the container port, so Tailscale proxies to `127.0.0.1:<host-port>`.
+- Or use the [Tailscale Sidecar](#tailscale-sidecar) on the same Docker network as the app. Prefer that over `network_mode: host` on rootless Docker.
+
 ### Tailscale Sidecar
 
 Use this setup when the host does not run Tailscale directly. It is the required setup on macOS and Windows (Docker Desktop, OrbStack, Colima) and on many NAS devices, because `tailscaled` runs inside the Docker environment and shares its socket with DockTail through a named volume instead of a host mount:
@@ -74,4 +105,4 @@ volumes:
 
 Set `TAILSCALE_AUTH_KEY` to authenticate the Tailscale container. Generate it in the Tailscale Admin Console under Settings -> Keys. The sidecar should advertise `tag:server` so it can satisfy the ACL auto-approver example below.
 
-The sidecar uses `network_mode: host` so it can reach container IPs on any Docker network. On Docker Desktop this requires enabling host networking under Settings -> Resources -> Network. Alternatively, remove `network_mode: host` and attach the sidecar to the same Docker network as the containers you expose.
+The sidecar uses `network_mode: host` so it can reach container IPs on any Docker network. On Docker Desktop this requires enabling host networking under Settings -> Resources -> Network. Alternatively, remove `network_mode: host` and attach the sidecar to the same Docker network as the containers you expose. On rootless Docker, prefer the shared-network form; host networking is limited in that mode.

--- a/docs/04-labels.md
+++ b/docs/04-labels.md
@@ -16,7 +16,7 @@ services:
       - "docktail.service.port=80"
 ```
 
-Set `docktail.service.direct=false` to use published host ports instead. This is mainly useful for legacy setups or unusual networking constraints.
+Set `docktail.service.direct=false` to use published host ports instead. Use this for legacy setups, or when host `tailscaled` cannot reach container IPs (common with [rootless Docker](#rootless-docker)).
 
 ### Service Labels
 
@@ -26,7 +26,7 @@ Set `docktail.service.direct=false` to use published host ports instead. This is
 | `docktail.service.name` | Yes | - | Service name, such as `web` or `api`. |
 | `docktail.service.port` | Yes | - | Backend container port to proxy to. |
 | `docktail.service.description` | No | - | Human-readable description shown for the service in the Tailscale admin panel. Requires API credentials (synced to the Service definition's `comment`). |
-| `docktail.service.direct` | No | `true` | Proxy directly to container IP instead of requiring a published host port. |
+| `docktail.service.direct` | No | `true` | Proxy directly to container IP instead of requiring a published host port. Set `false` when host `tailscaled` cannot reach container IPs (rootless Docker). |
 | `docktail.service.network` | No | `bridge` or first available | Docker network used for direct container IP detection. |
 | `docktail.service.protocol` | No | Smart | Backend protocol. |
 | `docktail.service.service-port` | No | Smart | Port Tailscale listens on. |

--- a/docs/04-labels.md
+++ b/docs/04-labels.md
@@ -16,7 +16,7 @@ services:
       - "docktail.service.port=80"
 ```
 
-Set `docktail.service.direct=false` to use published host ports instead. Use this for legacy setups, or when host `tailscaled` cannot reach container IPs (common with [rootless Docker](#rootless-docker)).
+Set `docktail.service.direct=false` to use published host ports instead. Use this for legacy setups, or when host `tailscaled` cannot reach container IPs (common with [rootless Docker](02-installation.md#rootless-docker)).
 
 ### Service Labels
 

--- a/docs/05-examples.md
+++ b/docs/05-examples.md
@@ -102,6 +102,8 @@ networks:
 
 ### Legacy Published-Port Mode
 
+Use published host ports when you cannot proxy to the container IP. That includes older setups and [rootless Docker](#rootless-docker) with host Tailscale, where `tailscaled` often cannot reach container IPs.
+
 ```yaml
 services:
   app:

--- a/docs/05-examples.md
+++ b/docs/05-examples.md
@@ -102,7 +102,7 @@ networks:
 
 ### Legacy Published-Port Mode
 
-Use published host ports when you cannot proxy to the container IP. That includes older setups and [rootless Docker](#rootless-docker) with host Tailscale, where `tailscaled` often cannot reach container IPs.
+Use published host ports when you cannot proxy to the container IP. That includes older setups and [rootless Docker](02-installation.md#rootless-docker) with host Tailscale, where `tailscaled` often cannot reach container IPs.
 
 ```yaml
 services:

--- a/docs/07-reference.md
+++ b/docs/07-reference.md
@@ -16,7 +16,7 @@ Use this section when checking exact configuration names, defaults, and supporte
 | `SKIP_SHUTDOWN_CLEANUP` | `false` | When `true`, DockTail leaves its services and Funnels advertised on shutdown instead of draining and clearing them. This can keep ports exposed on the tailnet beyond what your current labels define; see [Cleanup Behavior](#cleanup-behavior). |
 | `LOG_LEVEL` | `info` | Logging level: `debug`, `info`, `warn`, or `error`. |
 | `RECONCILE_INTERVAL` | `60s` | State reconciliation interval. |
-| `DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon socket. |
+| `DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon socket. Rootless Docker typically uses `unix:///run/user/<uid>/docker.sock`. |
 | `TAILSCALE_SOCKET` | `/var/run/tailscale/tailscaled.sock` | Tailscale daemon socket. |
 
 If both OAuth and API key credentials are configured, DockTail uses OAuth.

--- a/docs/08-how-it-works.md
+++ b/docs/08-how-it-works.md
@@ -36,6 +36,6 @@ Tailnet clients access container services
 
 Direct mode is the default. DockTail reaches containers through their Docker network IPs, so application containers do not need published host ports.
 
-When `docktail.service.direct=false`, DockTail uses Docker published port bindings instead. In that mode, the target port must be published to the host. This is also the reliable path when host `tailscaled` cannot reach container IPs, which is common with [rootless Docker](#rootless-docker).
+When `docktail.service.direct=false`, DockTail uses Docker published port bindings instead. In that mode, the target port must be published to the host. This is also the reliable path when host `tailscaled` cannot reach container IPs, which is common with [rootless Docker](02-installation.md#rootless-docker).
 
 Containers using `network_mode: host` are served on `127.0.0.1` (IPv4, to avoid dual-stack `localhost`→`::1` refusals). The local health check probes them from wherever the agent runs: directly via `127.0.0.1` when the agent shares the host's network namespace, or via the agent's docker-network gateway (the host's bridge address) when the agent runs in its own container. Containers using `network_mode: none` cannot use direct mode.

--- a/docs/08-how-it-works.md
+++ b/docs/08-how-it-works.md
@@ -36,6 +36,6 @@ Tailnet clients access container services
 
 Direct mode is the default. DockTail reaches containers through their Docker network IPs, so application containers do not need published host ports.
 
-When `docktail.service.direct=false`, DockTail uses Docker published port bindings instead. In that mode, the target port must be published to the host.
+When `docktail.service.direct=false`, DockTail uses Docker published port bindings instead. In that mode, the target port must be published to the host. This is also the reliable path when host `tailscaled` cannot reach container IPs, which is common with [rootless Docker](#rootless-docker).
 
 Containers using `network_mode: host` are served on `127.0.0.1` (IPv4, to avoid dual-stack `localhost`→`::1` refusals). The local health check probes them from wherever the agent runs: directly via `127.0.0.1` when the agent shares the host's network namespace, or via the agent's docker-network gateway (the host's bridge address) when the agent runs in its own container. Containers using `network_mode: none` cannot use direct mode.

--- a/tailscale/funnel.go
+++ b/tailscale/funnel.go
@@ -445,6 +445,9 @@ func (c *Client) addFunnel(ctx context.Context, svc *apptypes.ContainerService) 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		stderr := string(output)
+		if isServeConfigDeniedError(stderr) {
+			return errors.New(serveConfigDeniedMessage("enable funnel"))
+		}
 		if isFunnelACLError(stderr) {
 			return fmt.Errorf(
 				"failed to enable funnel: this node is not allowed by your Tailscale funnel policy.\n"+

--- a/tailscale/service.go
+++ b/tailscale/service.go
@@ -3,6 +3,7 @@ package tailscale
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -193,6 +194,9 @@ func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService)
 			retryCmd := c.tailscaleCmd(ctx, "serve", serviceArg, portArg, destination)
 			retryOutput, retryErr := retryCmd.CombinedOutput()
 			if retryErr != nil {
+				if isServeConfigDeniedError(string(retryOutput)) {
+					return errors.New(serveConfigDeniedMessage("add service after clearing"))
+				}
 				return fmt.Errorf("failed to add service after clearing: %w\nOutput: %s", retryErr, string(retryOutput))
 			}
 
@@ -215,6 +219,10 @@ func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService)
 				"     \"autoApprovers\": { \"services\": { \"tag:container\": [\"tag:server\"] } }\n" +
 				"  3. Approve the service at https://login.tailscale.com/admin/services\n" +
 				"Full setup guide: https://github.com/marvinvr/docktail#tailscale-admin-setup")
+		}
+
+		if isServeConfigDeniedError(stderr) {
+			return errors.New(serveConfigDeniedMessage("add service"))
 		}
 
 		return fmt.Errorf("failed to add service: %w\nOutput: %s", err, stderr)

--- a/tailscale/utils.go
+++ b/tailscale/utils.go
@@ -116,6 +116,25 @@ func isUntaggedNodeError(stderr string) bool {
 	return strings.Contains(stderr, "service hosts must be tagged nodes")
 }
 
+// isServeConfigDeniedError reports whether tailscaled rejected a serve or
+// Funnel write because the connecting process is neither root nor the
+// configured operator. Common with rootless Docker against a host tailscaled.
+func isServeConfigDeniedError(stderr string) bool {
+	return strings.Contains(stderr, "serve config denied")
+}
+
+// serveConfigDeniedMessage is the operator-facing hint for isServeConfigDeniedError.
+func serveConfigDeniedMessage(action string) string {
+	return fmt.Sprintf("failed to %s: Tailscale denied the serve config write. "+
+		"The process talking to tailscaled is not root and is not the configured operator. "+
+		"This is common with rootless Docker on the host Tailscale setup.\n"+
+		"To fix this:\n"+
+		"  1. Host install: sudo tailscale set --operator=$USER\n"+
+		"     The node still needs an ACL tag (sudo tailscale up --advertise-tags=tag:server --reset if it is not tagged yet).\n"+
+		"  2. Or use the sidecar setup so DockTail talks to a containerized tailscaled instead of the host daemon.\n"+
+		"Rootless Docker notes: https://docktail.org/docs/#rootless-docker", action)
+}
+
 // isManagedService checks if a service name has the "svc:" prefix
 // This indicates it's managed by DockTail and safe to modify
 func isManagedService(serviceName string) bool {

--- a/tailscale/utils_test.go
+++ b/tailscale/utils_test.go
@@ -1,6 +1,7 @@
 package tailscale
 
 import (
+	"strings"
 	"testing"
 
 	apptypes "github.com/marvinvr/docktail/types"
@@ -120,6 +121,42 @@ func TestIsUntaggedNodeError(t *testing.T) {
 				t.Errorf("isUntaggedNodeError(%q) = %v, want %v", tt.stderr, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestIsServeConfigDeniedError(t *testing.T) {
+	tests := []struct {
+		name     string
+		stderr   string
+		expected bool
+	}{
+		{"exact tailscale phrasing", "sending serve config: Access denied: serve config denied", true},
+		{"bare denial", "serve config denied", true},
+		{"generic access denied is not enough", "Access denied", false},
+		{"unrelated error", "service hosts must be tagged nodes", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isServeConfigDeniedError(tt.stderr)
+			if result != tt.expected {
+				t.Errorf("isServeConfigDeniedError(%q) = %v, want %v", tt.stderr, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestServeConfigDeniedMessage(t *testing.T) {
+	got := serveConfigDeniedMessage("add service")
+	if !strings.Contains(got, "failed to add service") {
+		t.Errorf("serveConfigDeniedMessage() missing action: %q", got)
+	}
+	if !strings.Contains(got, "sudo tailscale set --operator=$USER") {
+		t.Errorf("serveConfigDeniedMessage() missing operator hint: %q", got)
+	}
+	if !strings.Contains(got, "https://docktail.org/docs/#rootless-docker") {
+		t.Errorf("serveConfigDeniedMessage() missing docs link: %q", got)
 	}
 }
 

--- a/tools/docsgen/main.go
+++ b/tools/docsgen/main.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -127,10 +128,21 @@ func readMarkdown(sourceDir string) (string, error) {
 		if i > 0 {
 			out.WriteString("\n\n")
 		}
-		out.Write(bytes.TrimSpace(body))
+		// Source files use NN-name.md#anchor so GitHub can jump across
+		// pages. The generated site is one HTML page, so collapse those
+		// to in-page hashes.
+		out.Write(bytes.TrimSpace(rewriteDocFileLinks(body)))
 		out.WriteByte('\n')
 	}
 	return out.String(), nil
+}
+
+// docFileLink matches a markdown link to another numbered docs file, with
+// an optional heading hash. The generated site concatenates those files.
+var docFileLink = regexp.MustCompile(`\]\(\d{2}-[a-z0-9-]+\.md(#[a-z0-9-]+)?\)`)
+
+func rewriteDocFileLinks(body []byte) []byte {
+	return docFileLink.ReplaceAll(body, []byte("]($1)"))
 }
 
 func renderMarkdown(source []byte) (string, []heading, error) {


### PR DESCRIPTION
## Summary

Fixes #79.

Host `tailscaled` only accepts serve-config writes from root or the configured operator. In rootless Docker the DockTail container is the host user, so `tailscale serve` fails with `Access denied: serve config denied`.

This PR:

- Detects that CLI error on service add (including the conflict-retry path) and Funnel enable, and prints the same style of fix as the untagged-node hint: `sudo tailscale set --operator=$USER`, or use the sidecar.
- Documents the host-setup operator step, the rootless Docker socket path, and the follow-on caveat that advertisement succeeding does not mean host `tailscaled` can reach container IPs.

`TS_DEBUG_FAKE_IPC_VERSION` is intentionally not documented. DockTail already applies that override when it detects a CLI/daemon mismatch.

## Test plan

- [x] Unit coverage for the new error matcher and hint text
- [ ] CI unit + e2e on this PR
- [ ] After merge: confirm the reporter can advertise, and whether `www` is actually reachable (direct vs published-port / sidecar)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added rootless Docker setup guidance, including permissions, socket configuration, networking, and published-port mode.
  * Expanded troubleshooting guidance for host-based Tailscale and rootless Docker environments.
  * Improved documentation navigation with clearer links and in-page anchors.

* **Bug Fixes**
  * Improved handling of denied Tailscale Serve configuration requests.
  * Added clearer remediation messages covering permissions, ACL tags, sidecar usage, and relevant documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->