### PR TITLE
cloud: answer Tailscale control-plane probes, drop the serve vantage

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Once you run DockTail on more than one machine, "is it still up?" gets tedious. 
 
 ```text
 ● down · OOM-killed                   →  Docker reported an OOM kill
-● local up · tailnet not served       →  the app is fine, the exposure isn't
+● local up · awaiting approval        →  the app is fine, the exposure isn't
 ● host offline · heartbeat missing    →  the box stopped reporting
 ```
 

--- a/cloud/collector.go
+++ b/cloud/collector.go
@@ -961,11 +961,17 @@ func (c *Collector) sendHello(ctx context.Context, conn *wsConn) bool {
 	if c.hostTempCap {
 		caps = append(caps, "host_temp")
 	}
-	// Advertised only with Tailscale API credentials in hand: the cloud probes
-	// exactly one capable host per tailnet, so claiming it without being able to
-	// answer would cost that tailnet its vantage.
+	// Two entries, not one. CapTailnetControl says "this agent understands the
+	// tailnet_probe frame" and is unconditional — it is what lets the cloud tell a
+	// current agent with no Tailscale credentials apart from an agent too old to
+	// answer at all, so it can say "set TAILSCALE_OAUTH_CLIENT_ID" instead of
+	// "upgrade your agent". CapTailnetControlAPI says "and it has credentials", and
+	// is what the cloud actually gates probing on: it asks exactly one capable host
+	// per tailnet, so claiming it without being able to answer would cost that
+	// tailnet its vantage.
+	caps = append(caps, proto.CapTailnetControl)
 	if c.tailnet != nil && c.tailnet.APIEnabled() {
-		caps = append(caps, proto.CapTailnetControl)
+		caps = append(caps, proto.CapTailnetControlAPI)
 	}
 	nodeID, tailnet := c.tailnetIdentity(ctx)
 	hello := proto.Hello{

--- a/cloud/collector.go
+++ b/cloud/collector.go
@@ -41,7 +41,7 @@ type Collector struct {
 	docker  *docker.Client
 	log     zerolog.Logger
 	checker *checker
-	tailnet tailnetSource // local netmap reader (serve state + peer liveness); nil ⇒ no tailnet vantage
+	tailnet tailnetSource // local daemon + Tailscale control-plane reader; nil ⇒ no tailnet signals
 
 	fingerprint   string
 	hostname      string
@@ -58,6 +58,10 @@ type Collector struct {
 	cfgVer       int
 	unmonitored  bool      // cloud reports this host inactive/past the plan cap; throttle output
 	lastTeaser   time.Time // last throttled teaser snapshot sent while unmonitored
+
+	probeMu     sync.Mutex                 // serializes control-plane probes; guards probedAt + probeReport
+	probedAt    time.Time                  // last Tailscale control-plane read, for the agent-side minimum interval
+	probeReport proto.TailnetControlReport // last answer, re-served when the cloud asks again too soon
 
 	statsMu      sync.Mutex           // guards prevCPU + prevCPUOther
 	prevCPU      map[string]cpuSample // last CPU counters per service container, for % deltas
@@ -88,9 +92,10 @@ type containerStats struct {
 
 // NewCollector builds a Collector, reading the host fingerprint (docker engine
 // ID) and versions up front. Returns an error only if the engine ID can't be
-// read — without it there is no stable host identity. ts is the local tailscale
-// daemon reader used to source the tailnet vantage from the host's own netmap;
-// pass nil (or a client with no tailnet) to run without the tailnet vantage.
+// read — without it there is no stable host identity. ts reads the local
+// tailscale daemon (peer liveness, node identity) and, when API credentials are
+// configured, the Tailscale control plane behind the tailnet vantage; pass nil
+// to run without any tailnet signals.
 func NewCollector(ctx context.Context, cfg Config, dc *docker.Client, ts tailnetSource, logger zerolog.Logger) (*Collector, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("cloud config: %w", err)
@@ -283,9 +288,9 @@ func (c *Collector) pruneStatsMap(present map[string]struct{}, prevCPU map[strin
 }
 
 // toService maps a reconciler ContainerService + docker enrichment onto the wire
-// Service. FQDN is left empty: the tailnet vantage is sourced from the host's own
-// `tailscale serve` config (see tailnet.go), keyed by service name + port, so the
-// cloud does not need the MagicDNS domain to classify serve state.
+// Service. FQDN is left empty: the tailnet vantage comes from the Tailscale
+// control plane keyed by service name (see tailnet.go), so the cloud does not
+// need the MagicDNS domain to classify it.
 func toService(cs *apptypes.ContainerService, info docker.CloudInfo, stats containerStats) proto.Service {
 	svc := proto.Service{
 		Key:            serviceKeyForContainerService(cs),
@@ -641,6 +646,9 @@ func (c *Collector) session(ctx context.Context, bo *backoff) (stop bool) {
 		return false
 	}
 
+	connCtx, connCancel := context.WithCancel(ctx)
+	defer connCancel()
+
 	ackCh := make(chan proto.HelloAck, 1)
 	h := handlers{
 		onHelloAck: func(ack proto.HelloAck) {
@@ -650,10 +658,12 @@ func (c *Collector) session(ctx context.Context, bo *backoff) (stop bool) {
 			}
 		},
 		onConfig: func(cfg proto.Config) { c.applyConfig(cfg) },
+		// Off the read loop: answering hits the Tailscale API, and a slow API
+		// must not stall the frames (and pongs) behind it.
+		onTailnetProbe: func(probe proto.TailnetProbe) {
+			go c.handleTailnetProbe(connCtx, conn, probe)
+		},
 	}
-
-	connCtx, connCancel := context.WithCancel(ctx)
-	defer connCancel()
 
 	runDone := make(chan error, 1)
 	go func() { runDone <- conn.run(connCtx, h) }()
@@ -797,26 +807,18 @@ func (c *Collector) runChecks(ctx context.Context, conn *wsConn) {
 	if unmonitored || len(services) == 0 {
 		return
 	}
+	// Local vantage only. The tailnet vantage is not a probe the agent runs: it
+	// is the Tailscale control plane's answer, reported on request as a
+	// tailnet_control frame (see tailnet.go), so nothing here may claim it.
 	results := c.checker.run(ctx, services, configs)
-	// Tailnet-vantage results from the host's own `tailscale serve` config (the
-	// netmap-sourced vantage — no credentials). nil when there is no tailnet, so
-	// the cloud leaves the tailnet vantage not_configured.
-	tnResults := c.tailnetResults(ctx, services)
-	frame := results
-	if len(tnResults) > 0 {
-		frame = make([]proto.CheckResult, 0, len(results)+len(tnResults))
-		frame = append(frame, results...)
-		frame = append(frame, tnResults...)
-	}
-	if len(frame) == 0 {
+	if len(results) == 0 {
 		return
 	}
-	c.send(conn, proto.TypeCheckResults, proto.CheckResults{Results: frame})
-	c.log.Debug().Int("results", len(results)).Int("tailnet_results", len(tnResults)).Msg("cloud: check results sent")
+	c.send(conn, proto.TypeCheckResults, proto.CheckResults{Results: results})
+	c.log.Debug().Int("results", len(results)).Msg("cloud: check results sent")
 	// Capture logs for services that just crossed the down-debounce edge — the
 	// probe-driven counterpart to maybeCaptureLogs. Sent after check_results so
-	// the excerpt lands once the cloud has opened the incident. Local results
-	// only: a not-published tailnet result must not inflate the local fail streak.
+	// the excerpt lands once the cloud has opened the incident.
 	c.captureOnCheckFailures(ctx, conn, services, results)
 }
 
@@ -959,10 +961,18 @@ func (c *Collector) sendHello(ctx context.Context, conn *wsConn) bool {
 	if c.hostTempCap {
 		caps = append(caps, "host_temp")
 	}
+	// Advertised only with Tailscale API credentials in hand: the cloud probes
+	// exactly one capable host per tailnet, so claiming it without being able to
+	// answer would cost that tailnet its vantage.
+	if c.tailnet != nil && c.tailnet.APIEnabled() {
+		caps = append(caps, proto.CapTailnetControl)
+	}
+	nodeID, tailnet := c.tailnetIdentity(ctx)
 	hello := proto.Hello{
 		ProtocolVersion: proto.ProtocolVersion,
 		Fingerprint:     c.fingerprint,
-		TailscaleNodeID: c.tailnetSelfID(ctx),
+		TailscaleNodeID: nodeID,
+		Tailnet:         tailnet,
 		Hostname:        c.hostname,
 		AgentVersion:    agentVersion,
 		DockerVersion:   c.dockerVersion,

--- a/cloud/proto/messages.go
+++ b/cloud/proto/messages.go
@@ -10,21 +10,23 @@ type MessageType string
 
 // Agent -> Cloud message types.
 const (
-	TypeHello        MessageType = "hello"         // first frame after connect
-	TypeSnapshot     MessageType = "snapshot"      // service catalog snapshot
-	TypeContainers   MessageType = "containers"    // non-docktail container inventory (metadata only)
-	TypeEvent        MessageType = "event"         // a single docker failure signal
-	TypeCheckResults MessageType = "check_results" // batched local-vantage probes
-	TypeLogExcerpt   MessageType = "log_excerpt"   // opt-in last N lines on incident
-	TypeHeartbeat    MessageType = "heartbeat"     // liveness, every HeartbeatInterval
-	TypeHostMetrics  MessageType = "host_metrics"  // periodic whole-host resource vitals
-	TypeTailnet      MessageType = "tailnet"       // local netmap view: peer device liveness
+	TypeHello          MessageType = "hello"           // first frame after connect
+	TypeSnapshot       MessageType = "snapshot"        // full state after each reconcile
+	TypeContainers     MessageType = "containers"      // non-docktail container inventory (metadata only)
+	TypeEvent          MessageType = "event"           // a single docker failure signal
+	TypeCheckResults   MessageType = "check_results"   // batched local-vantage probes
+	TypeLogExcerpt     MessageType = "log_excerpt"     // opt-in last N lines on incident
+	TypeHeartbeat      MessageType = "heartbeat"       // liveness, every HeartbeatInterval
+	TypeHostMetrics    MessageType = "host_metrics"    // periodic whole-host resource vitals
+	TypeTailnet        MessageType = "tailnet"         // local netmap view: peer device liveness
+	TypeTailnetControl MessageType = "tailnet_control" // Tailscale control-plane service state, answered on request
 )
 
 // Cloud -> Agent message types.
 const (
-	TypeHelloAck MessageType = "hello_ack" // accept/reject + assigned host id
-	TypeConfig   MessageType = "config"    // check config + log opt-in flags
+	TypeHelloAck     MessageType = "hello_ack"     // accept/reject + assigned host id
+	TypeConfig       MessageType = "config"        // check config + log opt-in flags
+	TypeTailnetProbe MessageType = "tailnet_probe" // ask the agent to refresh Tailscale control-plane service state
 )
 
 // Envelope wraps every frame on the wire. Payload is the JSON of the concrete
@@ -63,6 +65,7 @@ type Hello struct {
 	ProtocolVersion  int      `json:"protocol_version"`
 	Fingerprint      string   `json:"fingerprint"`                 // docker engine ID — the host identity & billable unit
 	TailscaleNodeID  string   `json:"tailscale_node_id,omitempty"` // mutable attribute, may be empty at boot
+	Tailnet          string   `json:"tailnet,omitempty"`           // tailnet name (e.g. "tail1234.ts.net") — groups hosts that share a control plane; empty ⇒ unknown/no tailnet
 	Hostname         string   `json:"hostname,omitempty"`          // display-only, may collide
 	AgentVersion     string   `json:"agent_version,omitempty"`
 	DockerVersion    string   `json:"docker_version,omitempty"`
@@ -318,6 +321,67 @@ type TailnetPeer struct {
 	LastSeen int64  `json:"last_seen,omitempty"`
 }
 
+// TailnetControlReport is the agent's answer to a [TailnetProbe]: what the
+// Tailscale *control plane* says about a set of services, read through the
+// Tailscale API with the credentials the OSS agent already holds
+// (TAILSCALE_OAUTH_CLIENT_ID/SECRET or TAILSCALE_API_KEY). It is the sole source
+// of the cloud's `tailnet` vantage.
+//
+// Why this and not the host's own `tailscale serve` config: serve state only says
+// "this host believes it is serving". It cannot see that the service is awaiting
+// admin approval, that its definition was deleted, or that the control plane
+// never registered the advertisement — all cases where the host looks healthy and
+// nobody can reach the service. The control plane is the authority; the local
+// serve config can lie.
+//
+// The credential never leaves the customer's host: the cloud asks a question and
+// receives metadata. Because one host's credentials cover the whole tailnet, the
+// cloud polls exactly ONE capable host per (workspace, tailnet) instead of having
+// every agent hammer the Tailscale API — see [TailnetProbe].
+//
+// Available=false means the agent could not answer at all (no credentials, no
+// tailnet, API refused). Reason carries a ControlUnavail* code so the UI can
+// explain what to do instead of showing a false outage. Additive and
+// metadata-only — no exec surface — and ProtocolVersion stays 1. An agent that
+// does not advertise [CapTailnetControl] is never probed, so an old agent simply
+// yields no tailnet vantage.
+type TailnetControlReport struct {
+	RequestID string                `json:"request_id,omitempty"` // echoes TailnetProbe.RequestID
+	Tailnet   string                `json:"tailnet,omitempty"`    // tailnet this answer covers; scopes which hosts it may be applied to
+	Available bool                  `json:"available"`
+	Reason    string                `json:"reason,omitempty"` // ControlUnavail*, set only when Available is false
+	CheckedAt int64                 `json:"checked_at"`       // unix ms the control plane was read
+	Services  []TailnetControlState `json:"services,omitempty"`
+}
+
+// TailnetControlState is the control plane's view of ONE service. Exists=false
+// means the control plane has no such service definition (HTTP 404) — the
+// service is published locally but the tailnet does not know about it.
+//
+// Hosts is every device the control plane believes advertises this service. The
+// cloud resolves per-service health by matching a host's tailscale_node_id
+// against these entries: no match ⇒ this host is not advertising, whatever its
+// local serve config claims.
+type TailnetControlState struct {
+	ServiceKey  string               `json:"service_key"`            // echoes the probed key, the cloud's service identity
+	ServiceName string               `json:"service_name,omitempty"` // tailscale service name, e.g. "svc:myapp"
+	Exists      bool                 `json:"exists"`
+	Hosts       []TailnetControlHost `json:"hosts,omitempty"`
+	Error       string               `json:"error,omitempty"` // per-service read failure; the cloud holds the previous state rather than inventing an outage
+}
+
+// TailnetControlHost is one device advertising a service, as the control plane
+// reports it. State is the normalized [ControlState] the agent derived from the
+// raw API fields; ApprovalLevel and Configured are the raw strings, carried for
+// display and forward-compatibility with control-plane vocabulary the agent does
+// not yet recognize.
+type TailnetControlHost struct {
+	NodeID        string `json:"node_id"` // tailscale StableNodeID, matched against hosts.tailscale_node_id
+	State         string `json:"state"`   // ControlState*
+	ApprovalLevel string `json:"approval_level,omitempty"`
+	Configured    string `json:"configured,omitempty"`
+}
+
 // ---------------------------------------------------------------------------
 // Cloud -> Agent
 // ---------------------------------------------------------------------------
@@ -384,6 +448,36 @@ type CheckConfig struct {
 	IntervalMS   int64  `json:"interval_ms"`
 }
 
+// TailnetProbe asks the agent to read the Tailscale control plane for the listed
+// services and answer with a [TailnetControlReport]. It is a REQUEST FOR
+// METADATA, not a command: the agent decides whether it can answer, the cloud
+// supplies no credentials and no destination beyond service names the agent
+// already published, and there is nothing to execute. The metadata-only
+// non-goals (no exec, no deploy, no shell) are unchanged.
+//
+// The cloud drives this instead of letting agents poll on their own so the
+// Tailscale API load does not scale with host count: one capable host per
+// (workspace, tailnet) is asked on an interval and on catalog changes, and its
+// answer covers every service on that tailnet. Agents enforce
+// [MinTailnetProbeIntervalMS] locally regardless of what the cloud asks, so a
+// buggy or hostile control plane can never turn the customer's own credentials
+// into an API-rate-limit incident.
+//
+// Sent only to agents that advertised [CapTailnetControl] in their Hello. An
+// older agent ignores the unknown frame type; the cloud never sends it one.
+type TailnetProbe struct {
+	RequestID string                `json:"request_id"`
+	Services  []TailnetProbeService `json:"services"`
+}
+
+// TailnetProbeService names one service to look up. ServiceKey is echoed back so
+// the cloud can map the answer to its own catalog without trusting the agent to
+// re-derive identity; ServiceName is the tailscale service name to query.
+type TailnetProbeService struct {
+	ServiceKey  string `json:"service_key"`
+	ServiceName string `json:"service_name"`
+}
+
 // Cloud-to-agent configuration limits. The frame cap is enforced before JSON
 // decoding by the agent; the item and field caps are enforced again after
 // decoding and by the control-plane write path.
@@ -396,6 +490,18 @@ const (
 	MinCheckIntervalMS      int64 = 5_000
 	DefaultCheckIntervalMS  int64 = 30_000
 	MaxCheckIntervalMS      int64 = 300_000
+
+	// MaxTailnetProbeServices bounds one [TailnetProbe]; the cloud pages larger
+	// catalogs across successive probes.
+	MaxTailnetProbeServices = 512
+	// MinTailnetProbeIntervalMS is the floor the AGENT enforces between two
+	// control-plane reads, independent of how often the cloud asks. It protects
+	// the customer's own Tailscale API quota from a buggy or hostile cloud.
+	MinTailnetProbeIntervalMS int64 = 60_000
+	// DefaultTailnetProbeIntervalMS is the cloud's polling cadence per
+	// (workspace, tailnet). Service state changes on human timescales (an admin
+	// approving a service), so this is deliberately slow.
+	DefaultTailnetProbeIntervalMS int64 = 300_000
 )
 
 // ---------------------------------------------------------------------------
@@ -405,7 +511,7 @@ const (
 // Vantages — the three points a service is observed from.
 const (
 	VantageLocal   = "local"   // agent -> container IP
-	VantageTailnet = "tailnet" // prober -> service FQDN over WireGuard
+	VantageTailnet = "tailnet" // Tailscale control plane: is the service advertised and approved?
 	VantagePublic  = "public"  // plain HTTP probe for Funnel services
 )
 
@@ -417,9 +523,58 @@ const (
 	ClassRefused    = "refused"
 	ClassTLS        = "tls"
 	ClassHTTP5xx    = "http_5xx"
-	ClassACLBlocked = "acl_blocked" // reserved for the deferred Control-API ACL audit; not produced by the netmap vantage
-	ClassServe      = "serve"       // tailnet vantage: service is up locally but not published via `tailscale serve`
+	ClassACLBlocked = "acl_blocked" // reserved for the deferred Control-API ACL audit; not produced by the tailnet vantage
 	ClassContainer  = "container"   // local down -> container problem
+
+	// Tailnet-vantage classes. All are derived from the Tailscale control plane
+	// (see [TailnetControlReport]), never from the host's local serve config.
+	ClassUnapproved     = "unapproved"      // advertised, but a human still has to approve it in the admin console
+	ClassNotAdvertised  = "not_advertised"  // the control plane does not list this host as advertising the service
+	ClassMisconfigured  = "misconfigured"   // the control plane has the host but its service config is invalid/incomplete
+	ClassServiceMissing = "service_missing" // no such service definition in the tailnet at all
+
+	// Deprecated: ClassServe was emitted by the removed `tailscale serve` vantage.
+	// Recognized so pre-existing incidents and stored rows still render; never
+	// produced. See docs/prober.md.
+	ClassServe = "serve"
+)
+
+// Tailnet control-plane service states, as normalized by the agent from the
+// Tailscale API. They mirror the states Tailscale itself shows in the admin
+// console. Unrecognized states from a newer control plane are passed
+// through verbatim and treated as [ControlStateUnknown] by the cloud.
+const (
+	ControlStateConnected       = "connected"           // advertised and approved — reachable
+	ControlStatePendingApproval = "pending_approval"    // advertised, awaiting admin approval — NOT reachable
+	ControlStateNeedsConfig     = "needs_configuration" // host known, config invalid or missing
+	ControlStatePreApproved     = "pre_approved"        // auto-approved but not yet advertising
+	ControlStateDraining        = "draining"            // deliberately winding down; existing conns still served
+	ControlStateNotAdvertised   = "not_advertised"      // control plane knows the service, not this host
+	ControlStateNoService       = "no_service"          // no such service definition in the tailnet
+	ControlStateUnknown         = "unknown"             // could not be determined
+)
+
+// CapTailnetControl is the [Hello.Capabilities] entry an agent advertises when it
+// can answer a [TailnetProbe] — i.e. it understands the frame AND has Tailscale
+// API credentials configured. The cloud probes only agents that advertise it, so
+// an older agent is never sent an unknown frame and simply has no tailnet
+// vantage.
+const CapTailnetControl = "tailnet_control"
+
+// Reasons a [TailnetControlReport] carries Available=false. The cloud surfaces
+// these verbatim so the UI can tell the operator what to fix rather than showing
+// a phantom outage.
+const (
+	ControlUnavailNoCredentials = "no_credentials" // no OAuth client / API key configured on the agent
+	ControlUnavailNoTailnet     = "no_tailnet"     // the host is not on a tailnet
+	ControlUnavailUnauthorized  = "unauthorized"   // 401 — credentials rejected
+	ControlUnavailForbidden     = "forbidden"      // 403 — credentials lack the Services read scope
+	ControlUnavailRateLimited   = "rate_limited"   // 429 — backing off
+	ControlUnavailAPIError      = "api_error"      // anything else (network, 5xx, unparseable)
+
+	// ControlUnavailUnsupported is synthesized BY THE CLOUD for a workspace whose
+	// hosts are all too old to answer a probe. It never appears on the wire.
+	ControlUnavailUnsupported = "unsupported"
 )
 
 // Caps for log capture (also enforced agent-side).

--- a/cloud/proto/messages.go
+++ b/cloud/proto/messages.go
@@ -343,8 +343,8 @@ type TailnetPeer struct {
 // tailnet, API refused). Reason carries a ControlUnavail* code so the UI can
 // explain what to do instead of showing a false outage. Additive and
 // metadata-only — no exec surface — and ProtocolVersion stays 1. An agent that
-// does not advertise [CapTailnetControl] is never probed, so an old agent simply
-// yields no tailnet vantage.
+// does not advertise [CapTailnetControlAPI] is never probed, so an agent without
+// credentials simply yields no tailnet vantage.
 type TailnetControlReport struct {
 	RequestID string                `json:"request_id,omitempty"` // echoes TailnetProbe.RequestID
 	Tailnet   string                `json:"tailnet,omitempty"`    // tailnet this answer covers; scopes which hosts it may be applied to
@@ -463,7 +463,7 @@ type CheckConfig struct {
 // buggy or hostile control plane can never turn the customer's own credentials
 // into an API-rate-limit incident.
 //
-// Sent only to agents that advertised [CapTailnetControl] in their Hello. An
+// Sent only to agents that advertised [CapTailnetControlAPI] in their Hello. An
 // older agent ignores the unknown frame type; the cloud never sends it one.
 type TailnetProbe struct {
 	RequestID string                `json:"request_id"`
@@ -554,27 +554,51 @@ const (
 	ControlStateUnknown         = "unknown"             // could not be determined
 )
 
-// CapTailnetControl is the [Hello.Capabilities] entry an agent advertises when it
-// can answer a [TailnetProbe] — i.e. it understands the frame AND has Tailscale
-// API credentials configured. The cloud probes only agents that advertise it, so
-// an older agent is never sent an unknown frame and simply has no tailnet
-// vantage.
-const CapTailnetControl = "tailnet_control"
+// The [Hello.Capabilities] entries for the tailnet vantage. They are deliberately
+// TWO entries, because the cloud must tell three states apart and one flag
+// cannot:
+//
+//   - neither                 ⇒ the agent predates the tailnet vantage
+//     ([ControlUnavailAgentOutdated])
+//   - CapTailnetControl alone ⇒ a current agent with no Tailscale API
+//     credentials ([ControlUnavailNoCredentials])
+//   - both                    ⇒ the agent can be probed
+//
+// Collapsing them would make "no credentials" — the common case, and the one
+// with a two-line fix — indistinguishable from "your agent is too old", sending
+// the operator after a problem they do not have.
+const (
+	// CapTailnetControl means the agent understands the [TailnetProbe] frame.
+	// Advertised unconditionally by every agent that has this code, credentials
+	// or not, so it is a pure version marker.
+	CapTailnetControl = "tailnet_control"
+	// CapTailnetControlAPI means the agent ALSO holds Tailscale API credentials
+	// and can actually answer a probe. The cloud probes only agents advertising
+	// it, so an agent is never asked a question it cannot answer.
+	CapTailnetControlAPI = "tailnet_control_api"
+)
 
 // Reasons a [TailnetControlReport] carries Available=false. The cloud surfaces
 // these verbatim so the UI can tell the operator what to fix rather than showing
 // a phantom outage.
 const (
-	ControlUnavailNoCredentials = "no_credentials" // no OAuth client / API key configured on the agent
-	ControlUnavailNoTailnet     = "no_tailnet"     // the host is not on a tailnet
-	ControlUnavailUnauthorized  = "unauthorized"   // 401 — credentials rejected
-	ControlUnavailForbidden     = "forbidden"      // 403 — credentials lack the Services read scope
-	ControlUnavailRateLimited   = "rate_limited"   // 429 — backing off
-	ControlUnavailAPIError      = "api_error"      // anything else (network, 5xx, unparseable)
+	// ControlUnavailNoCredentials is the common case: a working agent with no
+	// Tailscale API credentials. Sent by an agent that lost its credentials after
+	// connecting, and synthesized by the cloud for a host advertising
+	// [CapTailnetControl] without [CapTailnetControlAPI] — which is how it is
+	// normally reached, since such a host is never probed.
+	ControlUnavailNoCredentials = "no_credentials"
+	ControlUnavailNoTailnet     = "no_tailnet"   // the host is not on a tailnet
+	ControlUnavailUnauthorized  = "unauthorized" // 401 — credentials rejected
+	ControlUnavailForbidden     = "forbidden"    // 403 — credentials lack the Services read scope
+	ControlUnavailRateLimited   = "rate_limited" // 429 — backing off
+	ControlUnavailAPIError      = "api_error"    // anything else (network, 5xx, unparseable)
 
-	// ControlUnavailUnsupported is synthesized BY THE CLOUD for a workspace whose
-	// hosts are all too old to answer a probe. It never appears on the wire.
-	ControlUnavailUnsupported = "unsupported"
+	// ControlUnavailAgentOutdated is synthesized BY THE CLOUD for a host whose
+	// agent predates the tailnet vantage (it advertises neither capability). It
+	// never appears on the wire: an agent able to send it would by definition be
+	// new enough not to need it.
+	ControlUnavailAgentOutdated = "agent_outdated"
 )
 
 // Caps for log capture (also enforced agent-side).

--- a/cloud/tailnet.go
+++ b/cloud/tailnet.go
@@ -2,89 +2,273 @@ package cloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/marvinvr/docktail/cloud/proto"
 	"github.com/marvinvr/docktail/tailscale"
 )
 
-// tailnetSource is the read-only view of the local tailscaled the collector needs
-// to source the tailnet vantage from the host's OWN netmap — no API key, no
-// stored credentials. *tailscale.Client satisfies it. Nil when DockTail has no
-// tailscale client, in which case the collector simply omits the tailnet vantage.
+// tailnetSource is the read-only tailscale view the collector needs: the local
+// daemon (peer liveness, this node's identity, the tailnet name) plus the
+// control-plane reads that answer a [proto.TailnetProbe] with the credentials
+// DockTail already holds. *tailscale.Client satisfies it. Nil when DockTail has
+// no tailscale client, in which case the collector reports no peer liveness and
+// answers every probe as unavailable.
 type tailnetSource interface {
-	// GetCurrentServices returns the tailscale services currently published via
-	// `tailscale serve`, keyed by "svc:<name>:<port>".
-	GetCurrentServices(ctx context.Context) (map[string]tailscale.ServiceEndpoint, error)
-	// Status returns this node's stable ID and the liveness of the tailnet peers
-	// it can see, from `tailscale status`.
+	// Status returns this node's stable ID, its tailnet name, and the liveness
+	// of the tailnet peers it can see, from `tailscale status`.
 	Status(ctx context.Context) (*tailscale.TailnetStatus, error)
+	// APIEnabled reports whether Tailscale API credentials are configured.
+	// False ⇒ the control plane is unreadable and no probe can be answered.
+	APIEnabled() bool
+	// ServiceControlState reads the control plane's view of one service.
+	ServiceControlState(ctx context.Context, serviceName string) (tailscale.ServiceControlState, error)
 }
 
-// tailnetServeKey is the `tailscale serve` key for a service: "svc:<name>:<port>".
-// Empty when the service has no tailscale service name/port (e.g. a funnel-only
-// service), in which case it has no tailnet-serve vantage.
-func tailnetServeKey(svc proto.Service) string {
-	if svc.ServiceName == "" || svc.Port == "" {
-		return ""
+// tailnetProbeTimeout bounds one whole control-plane read (status plus every
+// service lookup) so a hanging Tailscale API cannot wedge the probe. Services
+// still outstanding when it fires fail individually, which the cloud holds
+// against their previous state rather than reading as an outage.
+const tailnetProbeTimeout = 60 * time.Second
+
+// handleTailnetProbe answers a cloud [proto.TailnetProbe] with a
+// [proto.TailnetControlReport]. It runs off the read loop because the
+// control-plane read is network I/O, and it is a metadata read only: the probe
+// carries no destination and nothing to execute, just service names this host
+// already published.
+func (c *Collector) handleTailnetProbe(ctx context.Context, conn *wsConn, probe proto.TailnetProbe) {
+	c.mu.RLock()
+	unmonitored := c.unmonitored
+	c.mu.RUnlock()
+	if unmonitored {
+		// The cloud drops operational frames from an unmonitored host, so
+		// answering would spend the customer's Tailscale API quota for nothing.
+		return
 	}
-	return fmt.Sprintf("svc:%s:%s", svc.ServiceName, svc.Port)
+	report := c.tailnetControlReport(ctx, probe)
+	report.RequestID = probe.RequestID
+	c.send(conn, proto.TypeTailnetControl, report)
+	c.log.Debug().
+		Str("request_id", probe.RequestID).
+		Bool("available", report.Available).
+		Str("reason", report.Reason).
+		Int("services", len(report.Services)).
+		Msg("cloud: tailnet control report sent")
 }
 
-// tailnetResults builds tailnet-vantage check results from the host's
-// `tailscale serve` config: OK ⇒ the service is published on the tailnet, !OK
-// (class serve) ⇒ it is up locally but not published. Returns nil when there is
-// no tailnet source or the serve config can't be read (no tailnet) — the cloud
-// then leaves the tailnet vantage not_configured and degrades to local + docker
-// signals. Only services with a tailscale service name/port get a result.
-func (c *Collector) tailnetResults(ctx context.Context, services []proto.Service) []proto.CheckResult {
-	if c.tailnet == nil {
-		return nil
+// tailnetControlReport reads the Tailscale control plane for the probed
+// services. Serialized: two overlapping probes must not double-spend the quota.
+func (c *Collector) tailnetControlReport(ctx context.Context, probe proto.TailnetProbe) proto.TailnetControlReport {
+	c.probeMu.Lock()
+	defer c.probeMu.Unlock()
+
+	if c.tailnet == nil || !c.tailnet.APIEnabled() {
+		// The expected case for most installs (no OAuth client or API key), not
+		// a fault: the cloud says "tailnet health needs credentials" instead of
+		// showing an outage, so this stays at debug.
+		c.log.Debug().Msg("cloud: tailnet probe: no tailscale API credentials")
+		return unavailableControlReport(proto.ControlUnavailNoCredentials, "")
 	}
-	served, err := c.tailnet.GetCurrentServices(ctx)
-	if err != nil {
-		c.log.Debug().Err(err).Msg("cloud: tailnet serve status unavailable; skipping tailnet vantage")
-		return nil
+
+	// The AGENT, not the cloud, enforces the floor between two control-plane
+	// reads: the quota being spent is the customer's, so a buggy or hostile
+	// control plane must never be able to turn it into a rate-limit incident.
+	// Asked again too soon we re-serve the previous answer verbatim (the caller
+	// stamps the new RequestID). It covers the previous probe's service set,
+	// which is acceptable because the cloud's own cadence is minutes.
+	gap := time.Duration(proto.MinTailnetProbeIntervalMS) * time.Millisecond
+	if !c.probedAt.IsZero() && time.Since(c.probedAt) < gap {
+		c.log.Debug().Str("request_id", probe.RequestID).Msg("cloud: tailnet probe below minimum interval, serving cached report")
+		return c.probeReport
 	}
-	now := nowMillis()
-	out := make([]proto.CheckResult, 0, len(services))
-	for _, svc := range services {
-		key := tailnetServeKey(svc)
-		if key == "" {
+
+	cctx, cancel := context.WithTimeout(ctx, tailnetProbeTimeout)
+	defer cancel()
+
+	st, err := c.tailnet.Status(cctx)
+	if err != nil || st == nil {
+		c.log.Debug().Err(err).Msg("cloud: tailnet probe: no tailnet")
+		return c.rememberControlReport(unavailableControlReport(proto.ControlUnavailNoTailnet, ""))
+	}
+
+	names, keys := dedupeProbeServices(probe.Services)
+	report := proto.TailnetControlReport{
+		Tailnet:   st.Tailnet,
+		Available: true,
+		CheckedAt: nowMillis(),
+		Services:  make([]proto.TailnetControlState, 0, len(names)),
+	}
+	for i, name := range names {
+		state, serr := c.tailnet.ServiceControlState(cctx, name)
+		if serr != nil {
+			// A failure on the FIRST lookup is global — rejected credentials, a
+			// missing scope, quota, or a dead API — so the whole report is
+			// unavailable with an operator-actionable reason. Once one lookup has
+			// succeeded the credentials demonstrably work, so a later failure is
+			// about that one service: it gets an Error and the cloud keeps its
+			// previous state instead of inventing an outage.
+			if i == 0 {
+				reason := controlUnavailReason(serr)
+				c.log.Warn().Err(serr).Str("reason", reason).Msg("cloud: tailnet control plane unreadable")
+				return c.rememberControlReport(unavailableControlReport(reason, st.Tailnet))
+			}
+			c.log.Debug().Err(serr).Str("service", name).Msg("cloud: tailnet control read failed for service")
+			report.Services = append(report.Services, erroredControlStates(name, keys[name], controlErrorText(serr))...)
 			continue
 		}
-		_, published := served[key]
-		res := proto.CheckResult{
-			ServiceKey: svc.Key,
-			Vantage:    proto.VantageTailnet,
-			Kind:       "serve",
-			OK:         published,
-			CheckedAt:  now,
+		hosts := make([]proto.TailnetControlHost, 0, len(state.Hosts))
+		for _, h := range state.Hosts {
+			hosts = append(hosts, proto.TailnetControlHost{
+				NodeID:        h.NodeID,
+				State:         controlStateToProto(h.State),
+				ApprovalLevel: h.ApprovalLevel,
+				Configured:    h.Configured,
+			})
 		}
-		if !published {
-			res.Class = proto.ClassServe
+		// One API call answers for every service key that shares the name.
+		for _, key := range keys[name] {
+			report.Services = append(report.Services, proto.TailnetControlState{
+				ServiceKey:  key,
+				ServiceName: state.ServiceName,
+				Exists:      state.Exists,
+				Hosts:       hosts,
+			})
 		}
-		out = append(out, res)
+	}
+	return c.rememberControlReport(report)
+}
+
+// rememberControlReport caches the answer and starts the minimum-interval clock.
+// Failures are cached too: a report that already cost an API call (or proved the
+// credentials wrong) must not be retried on the cloud's cadence.
+func (c *Collector) rememberControlReport(report proto.TailnetControlReport) proto.TailnetControlReport {
+	c.probedAt = time.Now()
+	c.probeReport = report
+	return report
+}
+
+// unavailableControlReport is an "I could not answer" report. Available=false
+// with a ControlUnavail* reason is explicitly not an outage: the cloud shows the
+// operator what to fix instead of a phantom failure.
+func unavailableControlReport(reason, tailnet string) proto.TailnetControlReport {
+	return proto.TailnetControlReport{
+		Tailnet:   tailnet,
+		Available: false,
+		Reason:    reason,
+		CheckedAt: nowMillis(),
+	}
+}
+
+// erroredControlStates marks every key behind one service name as unread.
+func erroredControlStates(serviceName string, keys []string, msg string) []proto.TailnetControlState {
+	out := make([]proto.TailnetControlState, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, proto.TailnetControlState{ServiceKey: key, ServiceName: serviceName, Error: msg})
 	}
 	return out
 }
 
-// tailnetSelfID reads this node's tailscale StableNodeID (best-effort, bounded)
-// for the hello frame. Empty when there is no tailnet — the cloud then can't
-// split THIS host's outages into agent_down vs host_down (falls back to
-// host_down).
-func (c *Collector) tailnetSelfID(ctx context.Context) string {
+// dedupeProbeServices reduces the probe to the unique tailscale service names to
+// query, in request order, plus the service keys each name answers for. Several
+// keys can share one service name (the same service on several ports) and each
+// NAME costs exactly one API call, so the customer's quota scales with the
+// tailnet's services rather than with the cloud's catalog. Entries past
+// [proto.MaxTailnetProbeServices] and entries missing a key or a name are ignored.
+func dedupeProbeServices(in []proto.TailnetProbeService) (names []string, keys map[string][]string) {
+	if len(in) > proto.MaxTailnetProbeServices {
+		in = in[:proto.MaxTailnetProbeServices]
+	}
+	keys = make(map[string][]string, len(in))
+	queriedFor := make(map[string]string, len(in)) // fold identity -> name actually queried
+	for _, svc := range in {
+		key := strings.TrimSpace(svc.ServiceKey)
+		name := strings.TrimSpace(svc.ServiceName)
+		if key == "" || name == "" {
+			continue
+		}
+		// "myapp" and "svc:myapp" address the same service; fold them so they
+		// don't cost two calls.
+		identity := strings.ToLower(strings.TrimPrefix(name, "svc:"))
+		queried, seen := queriedFor[identity]
+		if !seen {
+			queried = name
+			queriedFor[identity] = name
+			names = append(names, name)
+		}
+		keys[queried] = append(keys[queried], key)
+	}
+	return names, keys
+}
+
+// controlStateToProto maps the tailscale package's normalized state onto the
+// wire vocabulary. Explicit rather than a pass-through so the two can drift
+// without silently changing the wire; anything unrecognized becomes unknown,
+// never a failure state.
+func controlStateToProto(state string) string {
+	switch state {
+	case tailscale.ControlStateConnected:
+		return proto.ControlStateConnected
+	case tailscale.ControlStatePendingApproval:
+		return proto.ControlStatePendingApproval
+	case tailscale.ControlStateNeedsConfig:
+		return proto.ControlStateNeedsConfig
+	case tailscale.ControlStatePreApproved:
+		return proto.ControlStatePreApproved
+	case tailscale.ControlStateDraining:
+		return proto.ControlStateDraining
+	}
+	return proto.ControlStateUnknown
+}
+
+// controlUnavailReason maps a failed control-plane read onto the reason the UI
+// shows. The distinctions are the actionable ones: rotate the credential (401),
+// grant the Services read scope (403), or wait (429).
+func controlUnavailReason(err error) string {
+	switch tailscale.APIStatusCode(err) {
+	case http.StatusUnauthorized:
+		return proto.ControlUnavailUnauthorized
+	case http.StatusForbidden:
+		return proto.ControlUnavailForbidden
+	case http.StatusTooManyRequests:
+		return proto.ControlUnavailRateLimited
+	}
+	return proto.ControlUnavailAPIError
+}
+
+// controlErrorText summarizes a per-service read failure. The API response body
+// is deliberately dropped: it is unbounded third-party text and this string
+// leaves the host.
+func controlErrorText(err error) string {
+	if code := tailscale.APIStatusCode(err); code != 0 {
+		return fmt.Sprintf("tailscale api: http %d", code)
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return "tailscale api: timed out"
+	}
+	return "tailscale api: request failed"
+}
+
+// tailnetIdentity reads this node's tailscale StableNodeID and tailnet name
+// (best-effort, bounded) for the hello frame, in ONE `tailscale status` call.
+// The node ID is how the cloud splits THIS host's outages into agent_down vs
+// host_down (empty ⇒ it falls back to host_down) and how it matches this host
+// against a service's control-plane hosts; the tailnet name groups hosts that
+// share a control plane, so the cloud can probe one of them on behalf of all.
+func (c *Collector) tailnetIdentity(ctx context.Context) (nodeID, tailnet string) {
 	if c.tailnet == nil {
-		return ""
+		return "", ""
 	}
 	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	st, err := c.tailnet.Status(cctx)
 	if err != nil || st == nil {
-		return ""
+		return "", ""
 	}
-	return st.SelfNodeID
+	return st.SelfNodeID, st.Tailnet
 }
 
 // tailnetLoop reports the host's local-netmap peer liveness on the heartbeat

--- a/cloud/wsclient.go
+++ b/cloud/wsclient.go
@@ -27,10 +27,13 @@ const (
 	maxBackoff = 60 * time.Second
 )
 
-// handlers receive cloud->agent frames decoded by the read loop.
+// handlers receive cloud->agent frames decoded by the read loop. A handler runs
+// ON the read loop, so anything that blocks (network I/O) must hand off to a
+// goroutine.
 type handlers struct {
-	onHelloAck func(proto.HelloAck)
-	onConfig   func(proto.Config)
+	onHelloAck     func(proto.HelloAck)
+	onConfig       func(proto.Config)
+	onTailnetProbe func(proto.TailnetProbe)
 }
 
 // wsConn is a single live websocket connection with its own write pump.
@@ -149,6 +152,15 @@ func (c *wsConn) readLoop(h handlers) error {
 			var cfg proto.Config
 			if env.Decode(&cfg) == nil && h.onConfig != nil {
 				h.onConfig(cfg)
+			}
+		case proto.TypeTailnetProbe:
+			var probe proto.TailnetProbe
+			if derr := env.Decode(&probe); derr != nil {
+				c.log.Warn().Err(derr).Msg("cloud: undecodable tailnet_probe, ignoring")
+				continue
+			}
+			if h.onTailnetProbe != nil {
+				h.onTailnetProbe(probe)
 			}
 		default:
 			c.log.Debug().Str("type", string(env.Type)).Msg("cloud: ignoring unexpected frame type")

--- a/docs/03-tailscale-admin.md
+++ b/docs/03-tailscale-admin.md
@@ -13,7 +13,7 @@ OAuth is recommended. It enables automatic service creation and avoids expiring 
    - Devices -> Core: Write
    - Keys -> Auth Keys: Write (only when using the sidecar method)
 
-   These same permissions also cover the optional `DELETE_UNUSED_SERVICES` cleanup, which lists Services, inspects their advertising hosts, and deletes the ones no host advertises. No extra scope is required.
+   These same permissions also cover the optional `DELETE_UNUSED_SERVICES` cleanup, which lists Services, inspects their advertising hosts, and deletes the ones no host advertises. They also cover [DockTail Cloud](06-cloud.md#tailnet-health) tailnet health, which reads the same advertising-host data to tell an unapproved or unadvertised service from a broken container. No extra scope is required, and the credentials never leave the host.
 4. Add the credentials to DockTail:
 
 ```yaml
@@ -49,7 +49,7 @@ API keys can also be loaded from `FILE__TAILSCALE_API_KEY` or `TAILSCALE_API_KEY
 
 ### Manual Mode
 
-DockTail can run without credentials. It advertises services locally through the Tailscale CLI, but you must manually create service definitions in the Tailscale Admin Console and configure ACL auto-approvers.
+DockTail can run without credentials. It advertises services locally through the Tailscale CLI, but you must manually create service definitions in the Tailscale Admin Console and configure ACL auto-approvers. Without credentials, DockTail Cloud also cannot report tailnet health, since it has no way to read the control plane.
 
 ### ACL Configuration
 

--- a/docs/06-cloud.md
+++ b/docs/06-cloud.md
@@ -108,8 +108,11 @@ agent enforces its own minimum interval of 60 seconds between control-plane
 reads, re-serving its previous answer if asked sooner — your Tailscale API quota
 is yours, and nothing on the Cloud side can spend more of it than that.
 
-Without credentials the agent reports the tailnet vantage as unavailable with a
-reason, and Cloud says so instead of showing an outage. Local checks, Docker
+Without credentials the agent still says so explicitly: its hello advertises that
+it understands tailnet health but has no credentials for it, so Cloud reports "no
+Tailscale credentials" and links to [Tailscale Admin
+Setup](03-tailscale-admin.md#tailscale-admin-setup) rather than showing an outage —
+or telling you to upgrade an agent that is already current. Local checks, Docker
 events, metrics, and incidents are unaffected.
 
 ### Identity

--- a/docs/06-cloud.md
+++ b/docs/06-cloud.md
@@ -7,7 +7,7 @@ DockTail Cloud is optional, opt-in monitoring for DockTail-managed services acro
 ### What You Get
 
 - **One view of every host and service.** The full catalog of DockTail-managed services, plus a read-only inventory of the host's other containers, with health history.
-- **The useful distinction.** A plain uptime check stops at "down." Cloud already has the Docker and Tailscale context, so it separates a *container* problem (exit code, Docker OOM event, restart loop) from an *exposure* problem (the container answers locally, but its Tailscale service isn't published) from a *host* problem (the box stopped sending heartbeats).
+- **The useful distinction.** A plain uptime check stops at "down." Cloud already has the Docker and Tailscale context, so it separates a *container* problem (exit code, Docker OOM event, restart loop) from an *exposure* problem (the container answers locally, but the Tailscale control plane says the service is awaiting approval, not advertised by this host, or gone) from a *host* problem (the box stopped sending heartbeats).
 - **Incidents with the evidence attached.** Docker failure events and a bounded log tail captured at the moment of failure, so you start from the reason instead of from a graph.
 - **Alerts and recoveries.** Notification when a service breaks and when it comes back — including hosts that drop off entirely, since detection runs in Cloud rather than on the box.
 
@@ -40,7 +40,7 @@ With no key set, no connection is opened and DockTail runs exactly as before.
 If Cloud marks a host as unmonitored (for example, the host sits past the
 workspace's host cap), the agent keeps the connection open with heartbeats and
 occasional catalog snapshots and pauses checks, Docker events, metrics, tailnet
-state, and log excerpts. Cloud pushes an updated configuration over the same
+state, tailnet-health answers, and log excerpts. Cloud pushes an updated configuration over the same
 connection when that changes; the agent does not need a restart.
 
 ### Environment Variables
@@ -66,14 +66,51 @@ When enabled, the agent reports the following operational data:
 - A read-only inventory of the host's **other** containers — the ones *not* published with `docktail.*` labels, including stopped ones — with name, image, state/health, ports, and live CPU/memory. These containers are not actively probed; they are listed on the dashboard so you can see the host's whole Docker footprint, and can be explicitly watched for Docker-event-driven incidents and alerts.
 - Docker failure events, including container exit codes, out-of-memory (OOM) kills, health-status changes, and restart loops.
 - Local-vantage check results. Checks default to TCP; cloud-managed config may select HTTP, a relative path, and expected status, but the destination always comes from the agent's local service discovery.
+- Tailscale control-plane service state, when Cloud asks for it (see [Tailnet Health](#tailnet-health)).
 - Bounded incident log excerpts when the workspace opts in. Before sending, the agent best-effort redacts common Authorization/Bearer credentials, passwords, tokens, API keys, credential URLs, JWTs, and private-key blocks, then applies the 40-line/8-KiB caps. Redaction cannot recognize every application-specific secret.
 
 ### What It Never Does
 
 - No remote command execution, deployment, or shell access. The protocol is metadata-only and has no exec, deploy, or shell message types.
 - It never executes anything on the host on behalf of the cloud.
-- Cloud configuration cannot select an arbitrary network destination; checks are bound to services discovered locally from Docker.
+- Cloud configuration cannot select an arbitrary network destination; checks are bound to services discovered locally from Docker. A tailnet-health request carries only service names the agent itself published, and carries no credentials.
+- Tailscale credentials stay on the host. Cloud never receives an OAuth client, an API key, or a Tailscale token — only the metadata the agent reads with them.
 - The connection is outbound only; the agent dials the ingest endpoint and nothing dials in.
+
+### Tailnet Health
+
+Cloud's tailnet vantage answers one question: does the Tailscale *control plane*
+agree that this host is advertising the service and that the service is approved?
+Answering it needs Tailscale API credentials, so it only works when
+`TAILSCALE_OAUTH_CLIENT_ID`/`TAILSCALE_OAUTH_CLIENT_SECRET` or
+`TAILSCALE_API_KEY` is already configured (see
+[Tailscale Admin Setup](03-tailscale-admin.md#tailscale-admin-setup)). No new
+credential, and none of them ever leaves the host: Cloud asks a question, the
+agent reads the Tailscale API and answers with metadata.
+
+It reads the control plane rather than the host's own `tailscale serve` config
+because serve state only says "this host believes it is serving." It cannot see
+that the service is waiting for approval in the Admin Console, that its
+definition was deleted, or that the advertisement never reached the control
+plane — cases where the host looks perfectly healthy and nobody can reach the
+service.
+
+This is an approval and advertisement oracle, not a reachability ping. Tailscale
+exposes no health or liveness probe for a service, so a service Cloud reports as
+`connected` is one the control plane considers advertised and approved — nothing
+more. Actual reachability still comes from the local vantage and, for Funnel
+services, the public one.
+
+Cloud drives the polling: it asks exactly one credentialed host per tailnet on a
+slow cadence (service state changes when a human approves something), and that
+answer covers every host on the tailnet. Agents never poll on their own, and each
+agent enforces its own minimum interval of 60 seconds between control-plane
+reads, re-serving its previous answer if asked sooner — your Tailscale API quota
+is yours, and nothing on the Cloud side can spend more of it than that.
+
+Without credentials the agent reports the tailnet vantage as unavailable with a
+reason, and Cloud says so instead of showing an outage. Local checks, Docker
+events, metrics, and incidents are unaffected.
 
 ### Identity
 
@@ -84,5 +121,9 @@ the hosts it already enrolled but cannot add another fingerprint until an
 operator reopens enrollment in the Cloud dashboard. An agent waiting for a
 reopened window retries automatically at a low rate.
 
-Service publish state is read from the host's local Tailscale daemon; the agent
-does not need to report an FQDN for that vantage.
+The agent also reports its own Tailscale node ID and tailnet name when it has a
+tailnet. The node ID lets Cloud tell a dead agent from a dead host and match this
+host against a service's advertising devices; the tailnet name groups the hosts
+that share a control plane, so Cloud knows which single host to ask for tailnet
+health. Neither is required — without them the agent simply reports fewer
+signals.

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -675,6 +675,9 @@ type serviceHost struct {
 
 // listServiceHosts returns the devices currently advertising the given Service.
 // An empty slice means no host is advertising it, i.e. the Service is unused.
+// A non-2xx response is returned as an *APIStatusError so callers can tell
+// "no such Service definition" (404) and credential/quota problems (401/403/429)
+// apart from a transport failure.
 func (c *Client) listServiceHosts(ctx context.Context, serviceName string) ([]serviceHost, error) {
 	apiURL := fmt.Sprintf("%s/api/v2/tailnet/%s/services/%s/devices", c.baseURL, url.PathEscape(c.tailnet), url.PathEscape(serviceName))
 
@@ -691,7 +694,7 @@ func (c *Client) listServiceHosts(ctx context.Context, serviceName string) ([]se
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("list service hosts API returned error status %d: %s", resp.StatusCode, string(body))
+		return nil, &APIStatusError{Op: "list service hosts", StatusCode: resp.StatusCode, Body: string(body)}
 	}
 
 	var result struct {

--- a/tailscale/control.go
+++ b/tailscale/control.go
@@ -1,0 +1,165 @@
+package tailscale
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Control-plane service states, normalized from the Tailscale API's raw
+// approvalLevel/configured strings by normalizeControlState. They mirror the
+// states the Tailscale admin console shows for a Service's hosts.
+//
+// This vocabulary is deliberately duplicated rather than imported from
+// cloud/proto: the tailscale package must not depend on the cloud wire types
+// (the cloud module translates these across the boundary). The values match the
+// proto constants so the translation stays a straight mapping.
+const (
+	ControlStateConnected       = "connected"           // advertised and approved — reachable
+	ControlStatePendingApproval = "pending_approval"    // advertised, awaiting admin approval — NOT reachable
+	ControlStateNeedsConfig     = "needs_configuration" // host known, config invalid or missing
+	ControlStatePreApproved     = "pre_approved"        // auto-approved but not yet advertising
+	ControlStateDraining        = "draining"            // deliberately winding down; existing conns still served
+	ControlStateUnknown         = "unknown"             // vocabulary we don't recognize
+)
+
+// APIStatusError is a non-2xx response from the Tailscale API. It carries the
+// status code so callers can act on it (404 = no such Service definition, 401 =
+// credentials rejected, 403 = missing scope, 429 = quota) instead of matching on
+// error strings.
+type APIStatusError struct {
+	Op         string // short description of the call, e.g. "list service hosts"
+	StatusCode int
+	Body       string
+}
+
+func (e *APIStatusError) Error() string {
+	return fmt.Sprintf("%s API returned error status %d: %s", e.Op, e.StatusCode, e.Body)
+}
+
+// APIStatusCode returns the HTTP status carried by err, or 0 when err is not an
+// *APIStatusError (transport failure, decode failure, context cancellation).
+func APIStatusCode(err error) int {
+	var se *APIStatusError
+	if errors.As(err, &se) {
+		return se.StatusCode
+	}
+	return 0
+}
+
+// ServiceControlState is the Tailscale *control plane's* view of one Service:
+// whether the tailnet has a definition for it at all, and which devices it
+// believes are advertising it. It is an approval/advertisement oracle, not a
+// reachability probe — Tailscale exposes no liveness check for a Service.
+//
+// Exists is false when the tailnet has no such Service definition (HTTP 404):
+// a host may still be serving it locally, but nothing can resolve it.
+type ServiceControlState struct {
+	ServiceName string // as queried, "svc:"-prefixed
+	Exists      bool
+	Hosts       []ServiceControlHost
+}
+
+// ServiceControlHost is one device advertising a Service. State is the
+// normalized ControlState*; ApprovalLevel and Configured are the raw API strings,
+// kept for display and so an unrecognized vocabulary is still visible to a human.
+type ServiceControlHost struct {
+	NodeID        string // tailscale StableNodeID
+	State         string // ControlState*
+	ApprovalLevel string // raw
+	Configured    string // raw
+}
+
+// APIEnabled reports whether Tailscale API credentials (OAuth client or API key)
+// are configured. Without them only the local daemon is readable, so every
+// control-plane read is unavailable rather than failing.
+func (c *Client) APIEnabled() bool { return c.apiSyncEnabled }
+
+// ServiceControlState reads the control plane's view of one Service.
+//
+// A 404 is not an error: it is the answer "this tailnet has no such Service
+// definition", which is exactly the failure mode the local serve config cannot
+// see. Every other non-2xx is returned as an *APIStatusError so the caller can
+// map 401/403/429 onto the right operator-actionable reason.
+func (c *Client) ServiceControlState(ctx context.Context, serviceName string) (ServiceControlState, error) {
+	name := strings.TrimSpace(serviceName)
+	if name == "" {
+		return ServiceControlState{}, fmt.Errorf("empty service name")
+	}
+	// The API addresses Services by their "svc:"-prefixed name; labels may carry
+	// either form (same normalization as SyncServiceDefinition).
+	if !strings.HasPrefix(name, "svc:") {
+		name = "svc:" + name
+	}
+
+	out := ServiceControlState{ServiceName: name}
+	hosts, err := c.listServiceHosts(ctx, name)
+	if err != nil {
+		if APIStatusCode(err) == http.StatusNotFound {
+			return out, nil // Exists=false
+		}
+		return ServiceControlState{}, err
+	}
+	out.Exists = true
+	for _, h := range hosts {
+		if h.StableNodeID == "" {
+			continue
+		}
+		out.Hosts = append(out.Hosts, ServiceControlHost{
+			NodeID:        h.StableNodeID,
+			State:         normalizeControlState(h.ApprovalLevel, h.Configured),
+			ApprovalLevel: h.ApprovalLevel,
+			Configured:    h.Configured,
+		})
+	}
+	return out, nil
+}
+
+// normalizeControlState maps the raw approvalLevel/configured pair onto the
+// ControlState* vocabulary.
+//
+// The raw strings are UNVERIFIED against a live tailnet — this is the single
+// place they are interpreted, so matching is case-insensitive and by substring,
+// and anything unrecognized falls through to ControlStateUnknown. An unfamiliar
+// value from a newer control plane must never be read as a failure: a monitoring
+// agent that invents an outage from a vocabulary change is worse than one that
+// admits it doesn't know. The raw strings travel alongside the normalized state
+// so a human can still see what the API actually said.
+//
+// Order matters: the more specific states are tested first ("pre-approved"
+// contains "approved"; a host that is approved but misconfigured is not
+// reachable, so the configuration verdict outranks the approval one).
+func normalizeControlState(approvalLevel, configured string) string {
+	approval := strings.ToLower(strings.TrimSpace(approvalLevel))
+	config := strings.ToLower(strings.TrimSpace(configured))
+	both := approval + " " + config
+
+	switch {
+	case strings.Contains(both, "drain"):
+		return ControlStateDraining
+	case containsAny(approval, "unapprov", "not approv", "denied", "reject"):
+		// Undocumented negations: refuse to read them as "approved" (the
+		// substring would match) and refuse to guess which failure they are.
+		return ControlStateUnknown
+	case containsAny(both, "pending", "awaiting"):
+		return ControlStatePendingApproval
+	case containsAny(approval, "pre-approved", "pre_approved", "preapproved"):
+		return ControlStatePreApproved
+	case containsAny(config, "needs", "unconfigured", "not configured", "not-configured", "missing", "invalid"):
+		return ControlStateNeedsConfig
+	case containsAny(approval, "approved", "connected"):
+		return ControlStateConnected
+	}
+	return ControlStateUnknown
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/tailscale/status.go
+++ b/tailscale/status.go
@@ -8,12 +8,17 @@ import (
 )
 
 // TailnetStatus is a minimal view of `tailscale status --json`: this node's
-// stable ID plus the online/offline status of the tailnet devices (peers) it can
-// see. DockTail Cloud uses it (read over the local daemon, no API key) to report
-// peer device liveness so the cloud can tell a dead agent from a dead host.
+// stable ID, the tailnet it belongs to, and the online/offline status of the
+// tailnet devices (peers) it can see. DockTail Cloud uses it (read over the
+// local daemon, no API key) to report peer device liveness so the cloud can tell
+// a dead agent from a dead host.
 type TailnetStatus struct {
 	SelfNodeID string
-	Peers      []TailnetPeerStatus
+	// Tailnet names the tailnet this node is currently in. Best-effort: older
+	// daemons and a logged-out node report nothing, so an empty value means
+	// "unknown", never "no tailnet".
+	Tailnet string
+	Peers   []TailnetPeerStatus
 }
 
 // TailnetPeerStatus is one tailnet device's liveness as seen in this node's netmap.
@@ -27,8 +32,17 @@ type TailnetPeerStatus struct {
 // statusJSON is the subset of `tailscale status --json` (tailscaled's
 // ipnstate.Status) that we parse.
 type statusJSON struct {
-	Self *statusNode            `json:"Self"`
-	Peer map[string]*statusNode `json:"Peer"`
+	Self           *statusNode            `json:"Self"`
+	Peer           map[string]*statusNode `json:"Peer"`
+	CurrentTailnet *statusTailnet         `json:"CurrentTailnet"`
+}
+
+// statusTailnet is ipnstate.Status.CurrentTailnet. Name is the human-facing
+// tailnet name; MagicDNSSuffix (e.g. "tail1234.ts.net") is the fallback because
+// it identifies the same tailnet and is present whenever MagicDNS is on.
+type statusTailnet struct {
+	Name           string `json:"Name"`
+	MagicDNSSuffix string `json:"MagicDNSSuffix"`
 }
 
 type statusNode struct {
@@ -38,10 +52,10 @@ type statusNode struct {
 	LastSeen time.Time `json:"LastSeen"`
 }
 
-// Status runs `tailscale status --json` and parses this node's stable ID and the
-// liveness of the peers it can see. Returns an error if the daemon isn't
-// reachable or the output can't be parsed — callers treat that as "no tailnet"
-// and skip reporting (the tailnet vantage degrades to not_configured).
+// Status runs `tailscale status --json` and parses this node's stable ID, its
+// tailnet name, and the liveness of the peers it can see. Returns an error if
+// the daemon isn't reachable or the output can't be parsed — callers treat that
+// as "no tailnet" and skip reporting.
 func (c *Client) Status(ctx context.Context) (*TailnetStatus, error) {
 	cmd := c.tailscaleCmd(ctx, "status", "--json")
 	output, err := cmd.CombinedOutput()
@@ -55,6 +69,12 @@ func (c *Client) Status(ctx context.Context) (*TailnetStatus, error) {
 	out := &TailnetStatus{}
 	if st.Self != nil {
 		out.SelfNodeID = st.Self.ID
+	}
+	if st.CurrentTailnet != nil {
+		out.Tailnet = st.CurrentTailnet.Name
+		if out.Tailnet == "" {
+			out.Tailnet = st.CurrentTailnet.MagicDNSSuffix
+		}
 	}
 	for _, p := range st.Peer {
 		if p == nil || p.ID == "" {


### PR DESCRIPTION
The cloud module's tailnet vantage was sourced from this host's own `tailscale serve` config. That only ever says **"this host believes it is serving."** It cannot see:

- a service **awaiting admin approval** in the Tailscale console,
- a service **definition that was deleted** from the tailnet,
- an **advertisement the control plane never registered**.

In every one of those the host looks perfectly healthy and nobody can reach the service — the exact failure the cloud product exists to catch. The control plane is the authority; the local serve config can lie.

## What this does

Reads the **Tailscale control plane** (`api.tailscale.com`) using the credentials DockTail already holds (`TAILSCALE_OAUTH_CLIENT_ID`/`SECRET` or `TAILSCALE_API_KEY`), and answers a cloud-issued `tailnet_probe` with a `tailnet_control` report.

**The credential never leaves the host.** The cloud sends a list of service names this agent itself published and receives metadata back. There is nothing to execute and no destination to choose — the metadata-only non-goals (no exec, no deploy, no shell) are unchanged.

**The cloud drives the polling, not the agent.** One credential covers a whole tailnet, so per-agent polling would scale Tailscale API load with host count. The agent still enforces `proto.MinTailnetProbeIntervalMS` (60s) between control-plane reads *regardless of what the cloud asks* — the quota being spent is the customer's, so a buggy or hostile control plane must never be able to turn it into a rate-limit incident.

## Notable

- `tailscale/control.go` — `ServiceControlState` + `APIEnabled`, with a typed `APIStatusError` so **404** (no such service definition — itself a real answer) is distinguishable from **401/403/429** without matching on error strings. `listServiceHosts` now returns that typed error; `deleteUnusedServiceDefinitions` still treats it as "skip deletion" and `Error()` reproduces the previous message text.
- **Unrecognized `approvalLevel`/`configured` vocabulary normalizes to `unknown`, never to a failure.** The raw API value strings could not be verified against a live tailnet, so matching is case-insensitive and by substring, explicit negations are tested *before* `"approved"` (so `"unapproved"` can't substring-match into a false healthy), and anything unfamiliar falls through. A monitoring agent that invents an outage from a vocabulary change is worse than one that admits it doesn't know. The raw strings travel alongside for display.
- The probe handler runs **off the websocket read loop** — a hanging Tailscale API would otherwise block heartbeats and drop the connection.
- `CapTailnetControl` is advertised **only** when credentials exist, so an agent that cannot answer is never asked.
- `tailscale/status.go` now parses the tailnet name, which is what lets the cloud group hosts sharing a control plane.

## Without credentials

Inert. Reports `no_credentials` rather than a fault, and the cloud renders "here's what to configure" instead of a phantom outage. Local monitoring is unaffected. Peer liveness (`TypeTailnet`) is untouched.

## Compatibility

`ProtocolVersion` stays 1; `cloud/proto/messages.go` is hand-synced and verified wire-identical with the cloud repo's copy. Pairs with marvinvr/docktail-cloud#23 — **deploy order between the two does not matter**: an old agent against the new cloud is never probed and degrades to a "no data" vantage, and this agent against an old cloud simply never receives a probe. Same outcome either way.

## Follow-up (not blocking)

Each inbound probe spawns a goroutine that queues on `probeMu`; a misbehaving control plane could pile them up behind a 60s in-flight read. They drain to the cached answer, but `TryLock` would be strictly better.

## Testing

Not run, per repo convention — `go build ./... && go vet ./...` and `gofmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Tailscale tailnet health reporting through control-plane data.
  - Reports tailnet identity, service approval, advertisement, configuration, and connection states.
  - Supports cloud-issued health probes with rate limiting and unavailable-state handling.
  - OAuth credentials can now enable tailnet health reporting.

- **Bug Fixes**
  - Improved handling and visibility of Tailscale API errors.

- **Documentation**
  - Updated setup guidance, credential requirements, polling behavior, and manual-mode limitations.
  - Clarified that credentials remain on the host.

- **Style**
  - Updated DockTail Cloud status wording to “awaiting approval.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->